### PR TITLE
Add support for the Keithley 4215-CVU

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LCR Meter
 - Keithley 595
 - Keysight E4980A
 - Agilent 4284A
+- Keithley 4215-CVU
 
 DMM (Temperature)
 

--- a/diode_measurement/controller.py
+++ b/diode_measurement/controller.py
@@ -27,6 +27,7 @@ from .view.panels import K6517BPanel
 from .view.panels import K595Panel
 from .view.panels import E4980APanel
 from .view.panels import A4284APanel
+from .view.panels import K4215Panel
 
 # DMM
 from .view.panels import K2700Panel
@@ -191,6 +192,7 @@ class Controller(QtCore.QObject):
         role.addInstrumentPanel(K595Panel())
         role.addInstrumentPanel(E4980APanel())
         role.addInstrumentPanel(A4284APanel())
+        role.addInstrumentPanel(K4215Panel())
 
         # Temperatur
         role = self.view.addRole("DMM")

--- a/diode_measurement/driver/__init__.py
+++ b/diode_measurement/driver/__init__.py
@@ -7,6 +7,7 @@ from .k2410 import K2410
 from .k2470 import K2470
 from .k2657a import K2657A
 from .k2700 import K2700
+from .k4215 import K4215
 from .k6514 import K6514
 from .k6517b import K6517B
 from .e4980a import E4980A
@@ -22,6 +23,7 @@ DRIVERS: Dict[str, type] = {
     "K2470": K2470,
     "K2657A": K2657A,
     "K2700": K2700,
+    "K4215": K4215,
     "K6514": K6514,
     "K6517B": K6517B,
     "E4980A": E4980A,

--- a/diode_measurement/driver/k4215.py
+++ b/diode_measurement/driver/k4215.py
@@ -254,14 +254,6 @@ class K4215(LCRMeter):
             raise ValueError("Correction length must be 0, 1.5, or 3.0 meters")
         self._write(f":CVU:LENGTH {correction_length:.1f}")
 
-    def get_voltage_level(self) -> float:
-        """Get the current DC bias voltage level."""
-        try:
-            response = self._query(":CVU:DCV?")
-            return float(response.strip())
-        except Exception:
-            # Return 0 if query fails
-            return 0.0
 
     def set_voltage_level(self, level: float) -> None:
         """Set the DC bias voltage level."""
@@ -275,6 +267,11 @@ class K4215(LCRMeter):
             )
         self._write(f":CVU:DCV {level:.3E}")
 
+    def get_voltage_level(self) -> float:
+        """Get the current DC bias voltage level."""
+        # not implemented by the instrument, return 0
+        return 0.0
+
     def set_voltage_offset(self, offset: float) -> None:
         """Set the DC voltage offset level."""
         if not (-30.0 <= offset <= 30.0):
@@ -287,8 +284,8 @@ class K4215(LCRMeter):
 
     def get_voltage_offset(self) -> float:
         """Get the current DC voltage offset level."""
-        response = self._query(":CVU:DCV:OFFSET?")
-        return float(response.strip())
+        # not implemented by the instrument, return 0
+        return 0.0
 
     def _enable_bias_tee_dc_voltage(self):
         """Enable -10V DC at HI and LO terminals for P3 bias tee."""

--- a/diode_measurement/driver/k4215.py
+++ b/diode_measurement/driver/k4215.py
@@ -118,7 +118,7 @@ class K4215(LCRMeter):
 
         if level not in [0, 1e-6, 30e-6, 1e-3]:
             raise ValueError("AC current range must be one of: 0, 1uA, 30uA, 1mA")
-        
+
         self._write(f":CVU:ACZ:RANGE {level:.6E}")
 
     def set_output_enabled(self, enabled: bool) -> None:
@@ -130,7 +130,6 @@ class K4215(LCRMeter):
         """Check if the CVU output is enabled."""
         # not implemented in K4215
         return False
-
 
     def set_correction(self, open_state=False, short_state=False, load_state=False):
         """Enable or disable open, short, and load compensation."""
@@ -221,7 +220,9 @@ class K4215(LCRMeter):
             raise ValueError("Delay factor must be between 0 and 100")
 
         # Set speed with delay factor, filter factor and aperture
-        self._write(f":CVU:SPEED 3,{delay_factor:.3E},{filter_factor:.3E},{aperture:.3E}")
+        self._write(
+            f":CVU:SPEED 3,{delay_factor:.3E},{filter_factor:.3E},{aperture:.3E}"
+        )
 
     def set_amplitude_voltage(self, voltage: float) -> None:
         if not (0.01 <= voltage <= 1.0):
@@ -254,12 +255,10 @@ class K4215(LCRMeter):
             raise ValueError("Correction length must be 0, 1.5, or 3.0 meters")
         self._write(f":CVU:LENGTH {correction_length:.1f}")
 
-
     def set_voltage_level(self, level: float) -> None:
         """Set the DC bias voltage level."""
         if not (-30.0 <= level <= 30.0):
             raise ValueError("Bias voltage level must be between -30V and 30V")
-
 
         if self._external_bias_tee_enabled:
             raise RuntimeError(

--- a/diode_measurement/driver/k4215.py
+++ b/diode_measurement/driver/k4215.py
@@ -17,6 +17,8 @@ class K4215(LCRMeter):
 
     def reset(self) -> None:
         self._write("*RST")
+        # clear last errors
+        self._write(":ERROR:LAST:CLEAR")
 
     def clear(self) -> None:
         self._write("BC")

--- a/diode_measurement/driver/k4215.py
+++ b/diode_measurement/driver/k4215.py
@@ -1,0 +1,318 @@
+import time
+from typing import Tuple
+
+from .driver import LCRMeter, handle_exception
+
+__all__ = ["K4215"]
+
+
+class K4215(LCRMeter):
+
+    def __init__(self, resource):
+        super().__init__(resource)
+        self._external_bias_tee_enabled = False
+
+    def identity(self) -> str:
+        return self._query("*IDN?").strip()
+
+    def reset(self) -> None:
+        self._write("*RST")
+
+    def clear(self) -> None:
+        self._write("BC")
+
+    def next_error(self) -> Tuple[int, str]:
+        """Get the next error from the instrument's error queue."""
+        # KXCI uses :ERROR:LAST:GET to retrieve the last error
+        response = self._query(":ERROR:LAST:GET")
+
+        # Try to parse response in standard SCPI format: code,"message"
+        if "," in response and '"' in response:
+            try:
+                parts = response.split(",", 1)
+                code = int(parts[0])
+                message = parts[1].strip().strip('"')
+                return code, message
+            except Exception:
+                pass
+
+        # Try to parse response in format: message. (code)
+        if "(" in response and ")" in response:
+            try:
+                code_str = response.split("(")[-1].split(")")[0]
+                code = int(code_str)
+                message = response.split("(")[0].strip().rstrip(".")
+                return code, message
+            except Exception:
+                pass
+
+        # clear error
+        self._write(":ERROR:LAST:CLEAR")
+
+        # Fallback: return the raw response with error code -1
+        return -1, response.strip()
+
+    def configure(self, options: dict) -> None:
+        """Configure the CVU for measurements options."""
+        # Set CVU mode (0 = user mode)
+        self._write(":CVU:MODE 0")
+
+        # Configure external bias tee option
+        external_bias_tee = options.get("external_bias_tee.enabled", False)
+        self._external_bias_tee_enabled = external_bias_tee
+
+        # Enable -10V DC bias for P3 bias tee if selected
+        if self._external_bias_tee_enabled:
+            self._enable_bias_tee_dc_voltage()
+
+        # Configure impedance/function type, default CPRP
+        function_type = options.get("function.type", "CPRP")
+        self.set_function_impedance_type(function_type)
+
+        # Configure aperture/speed settings
+        aperture = options.get("aperture.aperture", 1)
+        filter_factor = options.get("aperture.filter_factor", 5)
+        delay_factor = options.get("aperture.delay_factor", 10)
+        self.set_aperture(aperture, filter_factor, delay_factor)
+
+        # Configure correction settings
+        correction_length = options.get("correction.length", 0)
+        self.set_correction_length(correction_length)
+
+        correction_open = options.get("correction.open.enabled", False)
+        correction_short = options.get("correction.short.enabled", False)
+        correction_load = options.get("correction.load.enabled", False)
+        self.set_correction(correction_open, correction_short, correction_load)
+
+        # Set measurement parameters
+        voltage = options.get("voltage", 0.2)
+        self.set_amplitude_voltage(voltage)
+
+        frequency = options.get("frequency", 100000.0)
+        self.set_amplitude_frequency(frequency)
+
+        # Set bias voltage only if external bias tee is NOT enabled
+        if not external_bias_tee:
+            bias_voltage = options.get("bias_voltage", None)
+            if bias_voltage is not None:
+                self.set_voltage_level(bias_voltage)
+
+        # Set AC impedance range if specified
+        ac_range = options.get("ac_range", None)
+        if ac_range is not None:
+            self.set_aci_range(ac_range)
+        else:
+            self.set_aci_range(0)  # Auto range
+
+    def set_aci_range(self, level: float) -> None:
+        """Set the AC current measurement range
+
+        Args:
+            level (float): AC current range in Amperes, between 1E1-6 and 1E-3.
+                           For auto range, use 0.
+        """
+        self._write(f":CVU:ACZ:RANGE {level:.6E}")
+
+    def set_output_enabled(self, enabled: bool) -> None:
+        """Enable or disable the CVU output."""
+        value = "1" if enabled else "0"
+        self._write(f":CVU:OUTPUT {value}")
+
+    def get_output_enabled(self) -> bool:
+        """Check if the CVU output is enabled."""
+        response = self._query(":CVU:OUTPUT?")
+        return response.strip() == "1"
+
+    def set_correction(self, open_state=False, short_state=False, load_state=False):
+        """Enable or disable open, short, and load compensation."""
+        open_val = 1 if open_state else 0
+        short_val = 1 if short_state else 0
+        load_val = 1 if load_state else 0
+        self._write(f":CVU:CORRECT {open_val},{short_val},{load_val}")
+
+    def _fetch(self, timeout=15.0, interval=0.250) -> str:
+        """Fetch measurement data with proper synchronization.
+
+        For KXCI CVU measurements, this method implements proper timing
+        and synchronization to ensure reliable measurements.
+        """
+        # Clear any previous errors and set up for measurement
+        try:
+            self._write_nowait("*CLS")
+            self._write_nowait("*OPC")
+        except Exception:
+            pass  # Continue if clear commands fail
+
+        threshold = time.time() + timeout
+        interval = min(timeout, interval)
+
+        # Trigger measurement
+        try:
+            self._write_nowait(":CVU:TRIG")
+        except Exception:
+            # If explicit trigger not supported, measurement might be continuous
+            pass
+
+        while time.time() < threshold:
+            try:
+                # Check if operation is complete
+                try:
+                    esr = int(self._query("*ESR?"))
+                    if esr & 0x1:  # Operation Complete bit
+                        return self._query(":CVU:MEASZ?")
+                except Exception:
+                    # If *ESR? not supported, try direct measurement query
+                    result = self._query(":CVU:MEASZ?")
+                    if result and result.strip():
+                        return result
+
+            except Exception:
+                # Continue trying until timeout
+                pass
+            time.sleep(interval)
+
+        raise RuntimeError(f"LCR reading timeout, exceeded {timeout:G} s")
+
+    def measure_impedance(self) -> Tuple[float, float]:
+        result = self._fetch().split(",")
+        try:
+            return float(result[0]), float(result[1])
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to parse impedance reading: {result!r}"
+            ) from exc
+
+    def set_function_impedance_type(self, impedance_type) -> None:
+        """ Set the impedance equivalent circuit representation.
+
+        Args:
+            impedance_type: Can be integer (0-7) or string ("CPRP", "CSRS", etc.)
+
+        CVU model types:
+        0: Z, theta
+        1: R + jX
+        2: Cp, Gp
+        3: Cs, Rs
+        4: Cp, D
+        5: Cs, D
+        7: Y, theta
+        """
+        if isinstance(impedance_type, str):
+            # Map string types to integer values
+            type_map = {
+                "ZTHETA": 0,
+                "RPLUSJX": 1,
+                "CPRP": 2,
+                "CPGP": 2,
+                "CSRS": 3,
+                "CPD": 4,
+                "CSD": 5,
+                "YTHETA": 7,
+            }
+            impedance_type = type_map.get(impedance_type.upper(), 2)  # Default to Cp,Rp
+        if not isinstance(impedance_type, int) or impedance_type not in [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            7,
+        ]:
+            impedance_type = 2  # Default to Cp,Rp if invalid
+
+        self._write(f":CVU:MODEL {impedance_type}")
+
+    def set_aperture(self, aperture=10, filter_factor=1, delay_factor=1) -> None:
+        """Set measurement speed and aperture settings.
+
+        Args:
+            aperture: Aperture setting in PLC (Power Line Cycles) (0.006-10.002)
+            filter_factor: Filter count for noise reduction
+            delay_factor: Delay factor for settling
+        """
+        # Ensure aperture is within valid range (PLC values)
+        aperture = max(0.006, min(10.002, float(aperture)))
+
+        # Set speed with delay factor, filter factor and aperture
+        self._write(f":CVU:SPEED 3,{delay_factor},{filter_factor},{aperture}")
+
+
+    def set_amplitude_voltage(self, voltage: float) -> None:
+        self._write(f":CVU:ACV {voltage:E}")
+
+    def set_amplitude_frequency(self, frequency: float) -> None:
+        self._write(f":CVU:FREQ {int(frequency)}")
+
+    def _write(self, message):
+        """Write command and wait for operation complete."""
+        self.resource.write(message)
+        self.resource.query("*OPC?")
+
+    def _write_nowait(self, message):
+        self.resource.write(message)
+
+    @handle_exception
+    def _query(self, message):
+        return self.resource.query(message).strip()
+
+    def set_correction_length(self, correction_length: int) -> None:
+        """Set cable length correction for the K4215.
+
+        Args:
+            correction_length: Cable length in meters (0, 1.5, or 3.0)
+        """
+        assert correction_length in [
+            0,
+            1.5,
+            3.0,
+        ], f"Invalid cable length: {correction_length}. Must be 0, 1.5, or 3.0 meters."
+        self._write(f":CVU:LENGTH {correction_length:.1f}")
+
+    def get_voltage_level(self) -> float:
+        """Get the current DC bias voltage level."""
+        try:
+            response = self._query(":CVU:DCV?")
+            return float(response.strip())
+        except Exception:
+            # Return 0 if query fails
+            return 0.0
+
+    def set_voltage_level(self, level: float) -> None:
+        """Set the DC bias voltage level."""
+        if self._external_bias_tee_enabled:
+            raise RuntimeError(
+                "Cannot change bias voltage level when external P3 bias tee is enabled"
+            )
+        self._write(f":CVU:DCV {level:.3E}")
+
+    def _enable_bias_tee_dc_voltage(self):
+        self._write(":CVU:CONFIG:ACVHI 1")
+        self._write(":CVU:CONFIG:DCVHI 1")
+        self._write(":CVU:DCV:OFFSET -10")
+        self._write(":CVU:DCV -10")
+
+    def compliance_tripped(self) -> bool:
+        """Check if current compliance is tripped."""
+        # K4215 doesn't have current compliance, always return False
+        return False
+
+    def measure_i(self) -> float:
+        """Measure current - not supported on K4215."""
+        return 0.0
+
+    def measure_iv(self) -> Tuple[float, float]:
+        """Measure current and voltage - not supported on K4215."""
+        return 0.0, 0.0
+
+    def set_current_compliance_level(self, level: float) -> None:
+        """Set current compliance - not supported on K4215."""
+        pass  # Not supported by K4215
+
+    def set_voltage_range(self, level: float) -> None:
+        """Set voltage range for the K4215."""
+        self._write(f":CVU:DCV:RANGE {level:.3E}")
+
+    def finalize(self):
+        """Clean up and reset the instrument."""
+        self.reset()

--- a/diode_measurement/view/panels.py
+++ b/diode_measurement/view/panels.py
@@ -12,6 +12,7 @@ __all__ = [
     "K2470Panel",
     "K2657APanel",
     "K2700Panel",
+    "K4215Panel",
     "K6514Panel",
     "K6517BPanel",
     "A4284APanel",
@@ -88,11 +89,9 @@ class InstrumentPanel(QtWidgets.QWidget):
     def setModel(self, model: str) -> None:
         self.setProperty("model", model)
 
-    def restoreDefaults(self) -> None:
-        ...
+    def restoreDefaults(self) -> None: ...
 
-    def setLocked(self, state: bool) -> None:
-        ...
+    def setLocked(self, state: bool) -> None: ...
 
     def bindParameter(self, key: str, parameter: Any) -> None:
         if key in self._parameters:
@@ -177,11 +176,11 @@ class K2410Panel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterCountLabel = QtWidgets.QLabel("Count")
+        self.filterFactorLabel = QtWidgets.QLabel("Count")
 
-        self.filterCountSpinBox = QtWidgets.QSpinBox()
-        self.filterCountSpinBox.setSingleStep(1)
-        self.filterCountSpinBox.setRange(2, 100)
+        self.filterFactorSpinBox = QtWidgets.QSpinBox()
+        self.filterFactorSpinBox.setSingleStep(1)
+        self.filterFactorSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -191,8 +190,8 @@ class K2410Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterCountLabel)
-        filterLayout.addWidget(self.filterCountSpinBox)
+        filterLayout.addWidget(self.filterFactorLabel)
+        filterLayout.addWidget(self.filterFactorSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -247,23 +246,25 @@ class K2410Panel(InstrumentPanel):
         # Parameters
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
-        self.bindParameter("route.terminals", WidgetParameter(self.routeTerminalsComboBox))
+        self.bindParameter(
+            "route.terminals", WidgetParameter(self.routeTerminalsComboBox)
+        )
 
         self.restoreDefaults()
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterCountSpinBox.setValue(10)
+        self.filterFactorSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
         self.routeTerminalsComboBox.setCurrentIndex(0)
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterCountSpinBox.setEnabled(not state)
+        self.filterFactorSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.routeTerminalsComboBox.setEnabled(not state)
@@ -280,11 +281,11 @@ class K2470Panel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterCountLabel = QtWidgets.QLabel("Count")
+        self.filterFactorLabel = QtWidgets.QLabel("Count")
 
-        self.filterCountSpinBox = QtWidgets.QSpinBox()
-        self.filterCountSpinBox.setSingleStep(1)
-        self.filterCountSpinBox.setRange(2, 100)
+        self.filterFactorSpinBox = QtWidgets.QSpinBox()
+        self.filterFactorSpinBox.setSingleStep(1)
+        self.filterFactorSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -294,8 +295,8 @@ class K2470Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterCountLabel)
-        filterLayout.addWidget(self.filterCountSpinBox)
+        filterLayout.addWidget(self.filterFactorLabel)
+        filterLayout.addWidget(self.filterFactorSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -359,17 +360,22 @@ class K2470Panel(InstrumentPanel):
         layout.setStretch(1, 1)
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
-        self.bindParameter("route.terminals", WidgetParameter(self.routeTerminalsComboBox))
-        self.bindParameter("system.breakdown.protection", WidgetParameter(self.breakdownProtectionCheckBox))
+        self.bindParameter(
+            "route.terminals", WidgetParameter(self.routeTerminalsComboBox)
+        )
+        self.bindParameter(
+            "system.breakdown.protection",
+            WidgetParameter(self.breakdownProtectionCheckBox),
+        )
 
         self.restoreDefaults()
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterCountSpinBox.setValue(10)
+        self.filterFactorSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
         self.routeTerminalsComboBox.setCurrentIndex(0)
@@ -377,7 +383,7 @@ class K2470Panel(InstrumentPanel):
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterCountSpinBox.setEnabled(not state)
+        self.filterFactorSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.routeTerminalsComboBox.setEnabled(not state)
@@ -393,11 +399,11 @@ class K2657APanel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterCountLabel = QtWidgets.QLabel("Count")
+        self.filterFactorLabel = QtWidgets.QLabel("Count")
 
-        self.filterCountSpinBox = QtWidgets.QSpinBox()
-        self.filterCountSpinBox.setSingleStep(1)
-        self.filterCountSpinBox.setRange(2, 100)
+        self.filterFactorSpinBox = QtWidgets.QSpinBox()
+        self.filterFactorSpinBox.setSingleStep(1)
+        self.filterFactorSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -408,8 +414,8 @@ class K2657APanel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterCountLabel)
-        filterLayout.addWidget(self.filterCountSpinBox)
+        filterLayout.addWidget(self.filterFactorLabel)
+        filterLayout.addWidget(self.filterFactorSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -447,7 +453,7 @@ class K2657APanel(InstrumentPanel):
         layout.setStretch(1, 1)
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -455,13 +461,13 @@ class K2657APanel(InstrumentPanel):
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterCountSpinBox.setValue(10)
+        self.filterFactorSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterCountSpinBox.setEnabled(not state)
+        self.filterFactorSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
 
@@ -470,6 +476,286 @@ class K2700Panel(InstrumentPanel):
 
     def __init__(self, parent: QtWidgets.QWidget = None) -> None:
         super().__init__("K2700", parent)
+
+
+class K4215Panel(InstrumentPanel):
+
+    def __init__(self, parent: QtWidgets.QWidget = None) -> None:
+        super().__init__("K4215", parent)
+
+        # AC amplitude
+
+        self.amplitudeGroupBox = QtWidgets.QGroupBox()
+        self.amplitudeGroupBox.setTitle("AC Amplitude")
+
+        self.amplitudeVoltageTimeLabel = QtWidgets.QLabel("Voltage")
+
+        self.amplitudeVoltageSpinBox = QtWidgets.QDoubleSpinBox()
+        self.amplitudeVoltageSpinBox.setSuffix(" mV")
+        self.amplitudeVoltageSpinBox.setDecimals(0)
+        self.amplitudeVoltageSpinBox.setRange(5, 20e3)
+        self.amplitudeVoltageSpinBox.setValue(100.0)
+
+        self.amplitudeFrequencyTimeLabel = QtWidgets.QLabel("Frequency")
+
+        self.amplitudeFrequencySpinBox = QtWidgets.QDoubleSpinBox()
+        self.amplitudeFrequencySpinBox.setSuffix(" kHz")
+        self.amplitudeFrequencySpinBox.setDecimals(3)
+        self.amplitudeFrequencySpinBox.setRange(0.020, 2e6)
+        self.amplitudeFrequencySpinBox.setValue(1e5)
+
+        self.amplitudeAlcCheckBox = QtWidgets.QCheckBox("Auto Level Control (ALC)")
+
+        amplitudeLayout = QtWidgets.QVBoxLayout(self.amplitudeGroupBox)
+        amplitudeLayout.addWidget(self.amplitudeVoltageTimeLabel)
+        amplitudeLayout.addWidget(self.amplitudeVoltageSpinBox)
+        amplitudeLayout.addWidget(self.amplitudeFrequencyTimeLabel)
+        amplitudeLayout.addWidget(self.amplitudeFrequencySpinBox)
+        # amplitudeLayout.addWidget(self.amplitudeAlcCheckBox)
+        amplitudeLayout.addStretch()
+
+        # External Bias Tee section
+        self.externalBiasTeeGroupBox = QtWidgets.QGroupBox()
+        self.externalBiasTeeGroupBox.setTitle("External Bias Tee")
+
+        self.externalBiasTeeCCheckBox = QtWidgets.QCheckBox(
+            "-10V DC Bias (only for P3 Bias Tee)"
+        )
+        self.externalBiasTeeCCheckBox.setStatusTip(
+            "Use external bias tee for DC bias voltage. When enabled, internal bias voltage control is disabled."
+        )
+
+        externalBiasTeeLayout = QtWidgets.QVBoxLayout(self.externalBiasTeeGroupBox)
+        externalBiasTeeLayout.addWidget(self.externalBiasTeeCCheckBox)
+        externalBiasTeeLayout.addStretch()
+
+        # Aperture
+
+        self.apertureGroupBox = QtWidgets.QGroupBox()
+        self.apertureGroupBox.setTitle("Aperture")
+
+        self.integrationTimeLabel = QtWidgets.QLabel("Integration Time")
+
+        self.integrationTimeComboBox = QtWidgets.QComboBox()
+        self.integrationTimeComboBox.addItem("Fast", "SHOR")
+        self.integrationTimeComboBox.addItem("Normal", "MED")
+        self.integrationTimeComboBox.addItem("Quiet", "LONG")
+        self.integrationTimeComboBox.addItem("Custom", "CUSTOM")
+
+        self.averagingRateLabel = QtWidgets.QLabel("Aperture (PLC)")
+
+        self.averagingRateSpinBox = QtWidgets.QDoubleSpinBox()
+        self.averagingRateSpinBox.setRange(0.006, 10.002)
+        self.averagingRateSpinBox.setDecimals(4)
+        self.averagingRateSpinBox.setValue(10.0)
+
+        self.filterFactorLabel = QtWidgets.QLabel("Filter Factor")
+
+        self.filterFactorSpinBox = QtWidgets.QDoubleSpinBox()
+        self.filterFactorSpinBox.setRange(0, 707.0)
+        self.filterFactorSpinBox.setDecimals(1)
+        self.filterFactorSpinBox.setValue(2.0)
+        self.filterFactorSpinBox.setStatusTip("Filter factor for noise reduction")
+
+        self.delayFactorLabel = QtWidgets.QLabel("Delay Factor")
+
+        self.delayFactorSpinBox = QtWidgets.QDoubleSpinBox()
+        self.delayFactorSpinBox.setRange(0.1, 100.0)
+        self.delayFactorSpinBox.setDecimals(1)
+        self.delayFactorSpinBox.setValue(1.0)
+        self.delayFactorSpinBox.setStatusTip("Delay factor for measurement timing")
+
+        apertureLayout = QtWidgets.QVBoxLayout(self.apertureGroupBox)
+        apertureLayout.addWidget(self.integrationTimeLabel)
+        apertureLayout.addWidget(self.integrationTimeComboBox)
+        apertureLayout.addWidget(self.averagingRateLabel)
+        apertureLayout.addWidget(self.averagingRateSpinBox)
+        apertureLayout.addWidget(self.filterFactorLabel)
+        apertureLayout.addWidget(self.filterFactorSpinBox)
+        apertureLayout.addWidget(self.delayFactorLabel)
+        apertureLayout.addWidget(self.delayFactorSpinBox)
+        apertureLayout.addStretch()
+
+        # Correction
+
+        self.correctionGroupBox = QtWidgets.QGroupBox()
+        self.correctionGroupBox.setTitle("Correction")
+
+        self.lengthLabel = QtWidgets.QLabel("Cable Length")
+
+        self.lengthComboBox = QtWidgets.QComboBox()
+        self.lengthComboBox.addItem("0 m", 0)
+        self.lengthComboBox.addItem("1.5 m", 1.5)
+        self.lengthComboBox.addItem("3.0 m", 3)
+
+        self.openEnabledCheckBox = QtWidgets.QCheckBox("Enable OPEN correction")
+        self.openEnabledCheckBox.setStatusTip("Enable OPEN correction")
+
+        self.shortEnabledCheckBox = QtWidgets.QCheckBox("Enable SHORT correction")
+        self.shortEnabledCheckBox.setStatusTip("Enable SHORT correction")
+
+        correctionLayout = QtWidgets.QVBoxLayout(self.correctionGroupBox)
+        correctionLayout.addWidget(self.lengthLabel)
+        correctionLayout.addWidget(self.lengthComboBox)
+        correctionLayout.addWidget(self.openEnabledCheckBox)
+        correctionLayout.addWidget(self.shortEnabledCheckBox)
+        correctionLayout.addStretch()
+
+        # Layout
+
+        leftLayout = QtWidgets.QVBoxLayout()
+        leftLayout.addWidget(self.amplitudeGroupBox)
+        leftLayout.addWidget(self.externalBiasTeeGroupBox)
+
+        rightLayout = QtWidgets.QVBoxLayout()
+        rightLayout.addWidget(self.apertureGroupBox)
+        rightLayout.addWidget(self.correctionGroupBox)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(leftLayout)
+        layout.addLayout(rightLayout)
+        layout.addStretch()
+        layout.setStretch(0, 1)
+        layout.setStretch(1, 1)
+
+        self.bindParameter(
+            "voltage", MethodParameter(self.amplitudeVoltage, self.setAmplitudeVoltage)
+        )
+        self.bindParameter(
+            "frequency",
+            MethodParameter(self.amplitudeFrequency, self.setAmplitudeFrequency),
+        )
+        self.bindParameter("amplitude.alc", WidgetParameter(self.amplitudeAlcCheckBox))
+        self.bindParameter(
+            "aperture.integration_time", WidgetParameter(self.integrationTimeComboBox)
+        )
+        self.bindParameter(
+            "aperture.aperture", WidgetParameter(self.averagingRateSpinBox)
+        )
+        self.bindParameter(
+            "aperture.filter_count", WidgetParameter(self.filterFactorSpinBox)
+        )
+        self.bindParameter(
+            "aperture.delay_factor", WidgetParameter(self.delayFactorSpinBox)
+        )
+        self.bindParameter("correction.length", WidgetParameter(self.lengthComboBox))
+        self.bindParameter(
+            "correction.open.enabled", WidgetParameter(self.openEnabledCheckBox)
+        )
+        self.bindParameter(
+            "correction.short.enabled", WidgetParameter(self.shortEnabledCheckBox)
+        )
+        self.bindParameter(
+            "external_bias_tee.enabled", WidgetParameter(self.externalBiasTeeCCheckBox)
+        )
+
+        # Connect signal to handle bias voltage control state
+        self.externalBiasTeeCCheckBox.toggled.connect(self.onExternalBiasTeeCToggled)
+
+        # Connect signal to handle integration time preset changes
+        self.integrationTimeComboBox.currentTextChanged.connect(
+            self.onIntegrationTimeChanged
+        )
+
+        # Connect signals to switch to Custom when manual changes are made
+        self.averagingRateSpinBox.valueChanged.connect(self.onManualParameterChange)
+        self.filterFactorSpinBox.valueChanged.connect(self.onManualParameterChange)
+        self.delayFactorSpinBox.valueChanged.connect(self.onManualParameterChange)
+
+        self.restoreDefaults()
+
+    def onExternalBiasTeeCToggled(self, checked: bool) -> None:
+        """Handle external bias tee checkbox toggle."""
+        # When external bias tee is enabled, warn user that bias voltage control is disabled
+        if checked:
+            self.setStatusTip(
+                "External bias tee enabled - internal bias voltage control is disabled"
+            )
+        else:
+            self.setStatusTip(
+                "External bias tee disabled - internal bias voltage control is available"
+            )
+
+    def onIntegrationTimeChanged(self, text: str) -> None:
+        """Handle integration time preset changes."""
+        # Define presets based on K4215 manual
+        presets = {
+            "Fast": {
+                "delay_factor": 0.7,
+                "filter_factor": 0.2,
+                "aperture_time": 1,
+            },
+            "Normal": {
+                "delay_factor": 1.0,
+                "filter_factor": 1.0,
+                "aperture_time": 10,
+            },
+            "Quiet": {
+                "delay_factor": 0.7,
+                "filter_factor": 1.3,
+                "aperture_time": 10,
+            },
+        }
+
+        # Only update if it's a preset (not Custom)
+        if text in presets:
+            preset = presets[text]
+
+            # Update delay factor (already scaled for display)
+            self.delayFactorSpinBox.setValue(preset["delay_factor"])
+
+            # Update filter count
+            self.filterFactorSpinBox.setValue(preset["filter_factor"])
+
+            # Set aperture time from preset
+            self.averagingRateSpinBox.setValue(preset["aperture_time"])
+
+    def onManualParameterChange(self) -> None:
+        """Switch to Custom mode when user manually changes parameters."""
+        # Only switch to Custom if currently on a preset
+        current_text = self.integrationTimeComboBox.currentText()
+        if current_text != "Custom":
+            # Temporarily disconnect the signal to avoid recursion
+            self.integrationTimeComboBox.currentTextChanged.disconnect()
+            self.integrationTimeComboBox.setCurrentText("Custom")
+            self.integrationTimeComboBox.currentTextChanged.connect(
+                self.onIntegrationTimeChanged
+            )
+
+    def amplitudeVoltage(self) -> float:
+        return self.amplitudeVoltageSpinBox.value() / 1e3  # mV to V
+
+    def setAmplitudeVoltage(self, voltage: float) -> None:
+        self.amplitudeVoltageSpinBox.setValue(voltage * 1e3)  # V to mV
+
+    def amplitudeFrequency(self) -> float:
+        return self.amplitudeFrequencySpinBox.value() * 1e3  # kHz to Hz
+
+    def setAmplitudeFrequency(self, frequency: float) -> None:
+        self.amplitudeFrequencySpinBox.setValue(frequency / 1e3)  # Hz to kHz
+
+    def restoreDefaults(self) -> None:
+        self.setAmplitudeVoltage(1e-1)
+        self.setAmplitudeFrequency(100e3)
+        self.amplitudeAlcCheckBox.setChecked(False)
+        self.integrationTimeComboBox.setCurrentIndex(1)
+        self.averagingRateSpinBox.setValue(10.0)
+        self.lengthComboBox.setCurrentIndex(0)
+        self.openEnabledCheckBox.setChecked(False)
+        self.shortEnabledCheckBox.setChecked(False)
+        self.externalBiasTeeCCheckBox.setChecked(False)
+
+    def setLocked(self, state: bool) -> None:
+        self.amplitudeVoltageSpinBox.setEnabled(not state)
+        self.amplitudeFrequencySpinBox.setEnabled(not state)
+        self.amplitudeAlcCheckBox.setEnabled(not state)
+        self.integrationTimeComboBox.setEnabled(not state)
+        self.averagingRateSpinBox.setEnabled(not state)
+        self.lengthComboBox.setEnabled(not state)
+        self.openEnabledCheckBox.setEnabled(not state)
+        self.shortEnabledCheckBox.setEnabled(not state)
+        self.externalBiasTeeCCheckBox.setEnabled(not state)
 
 
 class K6514Panel(InstrumentPanel):
@@ -523,11 +809,11 @@ class K6514Panel(InstrumentPanel):
 
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterCountLabel = QtWidgets.QLabel("Count")
+        self.filterFactorLabel = QtWidgets.QLabel("Count")
 
-        self.filterCountSpinBox = QtWidgets.QSpinBox()
-        self.filterCountSpinBox.setSingleStep(1)
-        self.filterCountSpinBox.setRange(2, 100)
+        self.filterFactorSpinBox = QtWidgets.QSpinBox()
+        self.filterFactorSpinBox.setSingleStep(1)
+        self.filterFactorSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -537,8 +823,8 @@ class K6514Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterCountLabel)
-        filterLayout.addWidget(self.filterCountSpinBox)
+        filterLayout.addWidget(self.filterFactorLabel)
+        filterLayout.addWidget(self.filterFactorSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         # filterLayout.addStretch()
@@ -582,10 +868,14 @@ class K6514Panel(InstrumentPanel):
 
         self.bindParameter("sense.range", WidgetParameter(self.senseRangeMetric))
         self.bindParameter("sense.auto_range", WidgetParameter(self.autoRangeCheckBox))
-        self.bindParameter("sense.auto_range.lower_limit", WidgetParameter(self.autoRangeLLimitMetric))
-        self.bindParameter("sense.auto_range.upper_limit", WidgetParameter(self.autoRangeULimitMetric))
+        self.bindParameter(
+            "sense.auto_range.lower_limit", WidgetParameter(self.autoRangeLLimitMetric)
+        )
+        self.bindParameter(
+            "sense.auto_range.upper_limit", WidgetParameter(self.autoRangeULimitMetric)
+        )
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -597,7 +887,7 @@ class K6514Panel(InstrumentPanel):
         self.autoRangeLLimitMetric.setValue(2e-12)
         self.autoRangeULimitMetric.setValue(20e-3)
         self.filterEnableCheckBox.setChecked(False)
-        self.filterCountSpinBox.setValue(10)
+        self.filterFactorSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(5.0)
         self.updateState(self.autoRangeCheckBox.isChecked())
@@ -608,7 +898,7 @@ class K6514Panel(InstrumentPanel):
         self.autoRangeLLimitMetric.setEnabled(not state)
         self.autoRangeULimitMetric.setEnabled(not state)
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterCountSpinBox.setEnabled(not state)
+        self.filterFactorSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.updateState(self.autoRangeCheckBox.isChecked())
@@ -671,7 +961,9 @@ class K6517BPanel(InstrumentPanel):
         self.sourceGroupBox.setTitle("Source")
 
         self.meterConnectCheckBox = QtWidgets.QCheckBox("Meter Connect")
-        self.meterConnectCheckBox.setStatusTip("Enable or disable V-source LO to ammeter LO connection.")
+        self.meterConnectCheckBox.setStatusTip(
+            "Enable or disable V-source LO to ammeter LO connection."
+        )
 
         sourceLayout = QtWidgets.QVBoxLayout(self.sourceGroupBox)
         sourceLayout.addWidget(self.meterConnectCheckBox)
@@ -683,11 +975,11 @@ class K6517BPanel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterCountLabel = QtWidgets.QLabel("Count")
+        self.filterFactorLabel = QtWidgets.QLabel("Count")
 
-        self.filterCountSpinBox = QtWidgets.QSpinBox()
-        self.filterCountSpinBox.setSingleStep(1)
-        self.filterCountSpinBox.setRange(2, 100)
+        self.filterFactorSpinBox = QtWidgets.QSpinBox()
+        self.filterFactorSpinBox.setSingleStep(1)
+        self.filterFactorSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -697,8 +989,8 @@ class K6517BPanel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterCountLabel)
-        filterLayout.addWidget(self.filterCountSpinBox)
+        filterLayout.addWidget(self.filterFactorLabel)
+        filterLayout.addWidget(self.filterFactorSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         # filterLayout.addStretch()
@@ -743,11 +1035,17 @@ class K6517BPanel(InstrumentPanel):
 
         self.bindParameter("sense.range", WidgetParameter(self.senseRangeMetric))
         self.bindParameter("sense.auto_range", WidgetParameter(self.autoRangeCheckBox))
-        self.bindParameter("sense.auto_range.lower_limit", WidgetParameter(self.autoRangeLLimitMetric))
-        self.bindParameter("sense.auto_range.upper_limit", WidgetParameter(self.autoRangeULimitMetric))
-        self.bindParameter("source.meter_connect", WidgetParameter(self.meterConnectCheckBox))
+        self.bindParameter(
+            "sense.auto_range.lower_limit", WidgetParameter(self.autoRangeLLimitMetric)
+        )
+        self.bindParameter(
+            "sense.auto_range.upper_limit", WidgetParameter(self.autoRangeULimitMetric)
+        )
+        self.bindParameter(
+            "source.meter_connect", WidgetParameter(self.meterConnectCheckBox)
+        )
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -760,7 +1058,7 @@ class K6517BPanel(InstrumentPanel):
         self.autoRangeULimitMetric.setValue(20e-3)
         self.meterConnectCheckBox.setChecked(False)
         self.filterEnableCheckBox.setChecked(False)
-        self.filterCountSpinBox.setValue(10)
+        self.filterFactorSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
 
@@ -771,7 +1069,7 @@ class K6517BPanel(InstrumentPanel):
         self.autoRangeULimitMetric.setEnabled(not state)
         self.meterConnectCheckBox.setEnabled(not state)
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterCountSpinBox.setEnabled(not state)
+        self.filterFactorSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.updateState(self.autoRangeCheckBox.isChecked())
@@ -881,14 +1179,27 @@ class A4284APanel(InstrumentPanel):
         layout.setStretch(0, 1)
         layout.setStretch(1, 1)
 
-        self.bindParameter("voltage", MethodParameter(self.amplitudeVoltage, self.setAmplitudeVoltage))
-        self.bindParameter("frequency", MethodParameter(self.amplitudeFrequency, self.setAmplitudeFrequency))
+        self.bindParameter(
+            "voltage", MethodParameter(self.amplitudeVoltage, self.setAmplitudeVoltage)
+        )
+        self.bindParameter(
+            "frequency",
+            MethodParameter(self.amplitudeFrequency, self.setAmplitudeFrequency),
+        )
         self.bindParameter("amplitude.alc", WidgetParameter(self.amplitudeAlcCheckBox))
-        self.bindParameter("aperture.integration_time", WidgetParameter(self.integrationTimeComboBox))
-        self.bindParameter("aperture.averaging_rate", WidgetParameter(self.averagingRateSpinBox))
+        self.bindParameter(
+            "aperture.integration_time", WidgetParameter(self.integrationTimeComboBox)
+        )
+        self.bindParameter(
+            "aperture.averaging_rate", WidgetParameter(self.averagingRateSpinBox)
+        )
         self.bindParameter("correction.length", WidgetParameter(self.lengthComboBox))
-        self.bindParameter("correction.open.enabled", WidgetParameter(self.openEnabledCheckBox))
-        self.bindParameter("correction.short.enabled", WidgetParameter(self.shortEnabledCheckBox))
+        self.bindParameter(
+            "correction.open.enabled", WidgetParameter(self.openEnabledCheckBox)
+        )
+        self.bindParameter(
+            "correction.short.enabled", WidgetParameter(self.shortEnabledCheckBox)
+        )
 
         self.restoreDefaults()
 
@@ -1022,14 +1333,27 @@ class E4980APanel(InstrumentPanel):
         layout.setStretch(0, 1)
         layout.setStretch(1, 1)
 
-        self.bindParameter("voltage", MethodParameter(self.amplitudeVoltage, self.setAmplitudeVoltage))
-        self.bindParameter("frequency", MethodParameter(self.amplitudeFrequency, self.setAmplitudeFrequency))
+        self.bindParameter(
+            "voltage", MethodParameter(self.amplitudeVoltage, self.setAmplitudeVoltage)
+        )
+        self.bindParameter(
+            "frequency",
+            MethodParameter(self.amplitudeFrequency, self.setAmplitudeFrequency),
+        )
         self.bindParameter("amplitude.alc", WidgetParameter(self.amplitudeAlcCheckBox))
-        self.bindParameter("aperture.integration_time", WidgetParameter(self.integrationTimeComboBox))
-        self.bindParameter("aperture.averaging_rate", WidgetParameter(self.averagingRateSpinBox))
+        self.bindParameter(
+            "aperture.integration_time", WidgetParameter(self.integrationTimeComboBox)
+        )
+        self.bindParameter(
+            "aperture.averaging_rate", WidgetParameter(self.averagingRateSpinBox)
+        )
         self.bindParameter("correction.length", WidgetParameter(self.lengthComboBox))
-        self.bindParameter("correction.open.enabled", WidgetParameter(self.openEnabledCheckBox))
-        self.bindParameter("correction.short.enabled", WidgetParameter(self.shortEnabledCheckBox))
+        self.bindParameter(
+            "correction.open.enabled", WidgetParameter(self.openEnabledCheckBox)
+        )
+        self.bindParameter(
+            "correction.short.enabled", WidgetParameter(self.shortEnabledCheckBox)
+        )
 
         self.restoreDefaults()
 
@@ -1105,7 +1429,9 @@ class BrandBoxPanel(InstrumentPanel):
 
         # Parameters
 
-        self.bindParameter("channels", MethodParameter(self.closedChannels, self.setClosedChannels))
+        self.bindParameter(
+            "channels", MethodParameter(self.closedChannels, self.setClosedChannels)
+        )
 
         self.restoreDefaults()
 

--- a/diode_measurement/view/panels.py
+++ b/diode_measurement/view/panels.py
@@ -176,11 +176,11 @@ class K2410Panel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterFactorLabel = QtWidgets.QLabel("Count")
+        self.filterCountLabel = QtWidgets.QLabel("Count")
 
-        self.filterFactorSpinBox = QtWidgets.QSpinBox()
-        self.filterFactorSpinBox.setSingleStep(1)
-        self.filterFactorSpinBox.setRange(2, 100)
+        self.filterCountSpinBox = QtWidgets.QSpinBox()
+        self.filterCountSpinBox.setSingleStep(1)
+        self.filterCountSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -190,8 +190,8 @@ class K2410Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterFactorLabel)
-        filterLayout.addWidget(self.filterFactorSpinBox)
+        filterLayout.addWidget(self.filterCountLabel)
+        filterLayout.addWidget(self.filterCountSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -246,7 +246,7 @@ class K2410Panel(InstrumentPanel):
         # Parameters
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
         self.bindParameter(
@@ -257,14 +257,14 @@ class K2410Panel(InstrumentPanel):
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterFactorSpinBox.setValue(10)
+        self.filterCountSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
         self.routeTerminalsComboBox.setCurrentIndex(0)
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterFactorSpinBox.setEnabled(not state)
+        self.filterCountSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.routeTerminalsComboBox.setEnabled(not state)
@@ -281,11 +281,11 @@ class K2470Panel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterFactorLabel = QtWidgets.QLabel("Count")
+        self.filterCountLabel = QtWidgets.QLabel("Count")
 
-        self.filterFactorSpinBox = QtWidgets.QSpinBox()
-        self.filterFactorSpinBox.setSingleStep(1)
-        self.filterFactorSpinBox.setRange(2, 100)
+        self.filterCountSpinBox = QtWidgets.QSpinBox()
+        self.filterCountSpinBox.setSingleStep(1)
+        self.filterCountSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -295,8 +295,8 @@ class K2470Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterFactorLabel)
-        filterLayout.addWidget(self.filterFactorSpinBox)
+        filterLayout.addWidget(self.filterCountLabel)
+        filterLayout.addWidget(self.filterCountSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -360,7 +360,7 @@ class K2470Panel(InstrumentPanel):
         layout.setStretch(1, 1)
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
         self.bindParameter(
@@ -375,7 +375,7 @@ class K2470Panel(InstrumentPanel):
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterFactorSpinBox.setValue(10)
+        self.filterCountSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
         self.routeTerminalsComboBox.setCurrentIndex(0)
@@ -383,7 +383,7 @@ class K2470Panel(InstrumentPanel):
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterFactorSpinBox.setEnabled(not state)
+        self.filterCountSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.routeTerminalsComboBox.setEnabled(not state)
@@ -399,11 +399,11 @@ class K2657APanel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterFactorLabel = QtWidgets.QLabel("Count")
+        self.filterCountLabel = QtWidgets.QLabel("Count")
 
-        self.filterFactorSpinBox = QtWidgets.QSpinBox()
-        self.filterFactorSpinBox.setSingleStep(1)
-        self.filterFactorSpinBox.setRange(2, 100)
+        self.filterCountSpinBox = QtWidgets.QSpinBox()
+        self.filterCountSpinBox.setSingleStep(1)
+        self.filterCountSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -414,8 +414,8 @@ class K2657APanel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterFactorLabel)
-        filterLayout.addWidget(self.filterFactorSpinBox)
+        filterLayout.addWidget(self.filterCountLabel)
+        filterLayout.addWidget(self.filterCountSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         filterLayout.addStretch()
@@ -453,7 +453,7 @@ class K2657APanel(InstrumentPanel):
         layout.setStretch(1, 1)
 
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -461,13 +461,13 @@ class K2657APanel(InstrumentPanel):
 
     def restoreDefaults(self) -> None:
         self.filterEnableCheckBox.setChecked(False)
-        self.filterFactorSpinBox.setValue(10)
+        self.filterCountSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
 
     def setLocked(self, state: bool) -> None:
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterFactorSpinBox.setEnabled(not state)
+        self.filterCountSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
 
@@ -809,11 +809,11 @@ class K6514Panel(InstrumentPanel):
 
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterFactorLabel = QtWidgets.QLabel("Count")
+        self.filterCountLabel = QtWidgets.QLabel("Count")
 
-        self.filterFactorSpinBox = QtWidgets.QSpinBox()
-        self.filterFactorSpinBox.setSingleStep(1)
-        self.filterFactorSpinBox.setRange(2, 100)
+        self.filterCountSpinBox = QtWidgets.QSpinBox()
+        self.filterCountSpinBox.setSingleStep(1)
+        self.filterCountSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -823,8 +823,8 @@ class K6514Panel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterFactorLabel)
-        filterLayout.addWidget(self.filterFactorSpinBox)
+        filterLayout.addWidget(self.filterCountLabel)
+        filterLayout.addWidget(self.filterCountSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         # filterLayout.addStretch()
@@ -875,7 +875,7 @@ class K6514Panel(InstrumentPanel):
             "sense.auto_range.upper_limit", WidgetParameter(self.autoRangeULimitMetric)
         )
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -887,7 +887,7 @@ class K6514Panel(InstrumentPanel):
         self.autoRangeLLimitMetric.setValue(2e-12)
         self.autoRangeULimitMetric.setValue(20e-3)
         self.filterEnableCheckBox.setChecked(False)
-        self.filterFactorSpinBox.setValue(10)
+        self.filterCountSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(5.0)
         self.updateState(self.autoRangeCheckBox.isChecked())
@@ -898,7 +898,7 @@ class K6514Panel(InstrumentPanel):
         self.autoRangeLLimitMetric.setEnabled(not state)
         self.autoRangeULimitMetric.setEnabled(not state)
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterFactorSpinBox.setEnabled(not state)
+        self.filterCountSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.updateState(self.autoRangeCheckBox.isChecked())
@@ -975,11 +975,11 @@ class K6517BPanel(InstrumentPanel):
         self.filterGroupBox.setTitle("Filter")
         self.filterEnableCheckBox = QtWidgets.QCheckBox("Enabled")
 
-        self.filterFactorLabel = QtWidgets.QLabel("Count")
+        self.filterCountLabel = QtWidgets.QLabel("Count")
 
-        self.filterFactorSpinBox = QtWidgets.QSpinBox()
-        self.filterFactorSpinBox.setSingleStep(1)
-        self.filterFactorSpinBox.setRange(2, 100)
+        self.filterCountSpinBox = QtWidgets.QSpinBox()
+        self.filterCountSpinBox.setSingleStep(1)
+        self.filterCountSpinBox.setRange(2, 100)
 
         self.filterModeLabel = QtWidgets.QLabel("Mode")
 
@@ -989,8 +989,8 @@ class K6517BPanel(InstrumentPanel):
 
         filterLayout = QtWidgets.QVBoxLayout(self.filterGroupBox)
         filterLayout.addWidget(self.filterEnableCheckBox)
-        filterLayout.addWidget(self.filterFactorLabel)
-        filterLayout.addWidget(self.filterFactorSpinBox)
+        filterLayout.addWidget(self.filterCountLabel)
+        filterLayout.addWidget(self.filterCountSpinBox)
         filterLayout.addWidget(self.filterModeLabel)
         filterLayout.addWidget(self.filterModeComboBox)
         # filterLayout.addStretch()
@@ -1045,7 +1045,7 @@ class K6517BPanel(InstrumentPanel):
             "source.meter_connect", WidgetParameter(self.meterConnectCheckBox)
         )
         self.bindParameter("filter.enable", WidgetParameter(self.filterEnableCheckBox))
-        self.bindParameter("filter.count", WidgetParameter(self.filterFactorSpinBox))
+        self.bindParameter("filter.count", WidgetParameter(self.filterCountSpinBox))
         self.bindParameter("filter.mode", WidgetParameter(self.filterModeComboBox))
         self.bindParameter("nplc", WidgetParameter(self.nplcSpinBox))
 
@@ -1058,7 +1058,7 @@ class K6517BPanel(InstrumentPanel):
         self.autoRangeULimitMetric.setValue(20e-3)
         self.meterConnectCheckBox.setChecked(False)
         self.filterEnableCheckBox.setChecked(False)
-        self.filterFactorSpinBox.setValue(10)
+        self.filterCountSpinBox.setValue(10)
         self.filterModeComboBox.setCurrentIndex(0)
         self.nplcSpinBox.setValue(1.0)
 
@@ -1069,7 +1069,7 @@ class K6517BPanel(InstrumentPanel):
         self.autoRangeULimitMetric.setEnabled(not state)
         self.meterConnectCheckBox.setEnabled(not state)
         self.filterEnableCheckBox.setEnabled(not state)
-        self.filterFactorSpinBox.setEnabled(not state)
+        self.filterCountSpinBox.setEnabled(not state)
         self.filterModeComboBox.setEnabled(not state)
         self.nplcSpinBox.setEnabled(not state)
         self.updateState(self.autoRangeCheckBox.isChecked())

--- a/tests/test_driver_k4125.py
+++ b/tests/test_driver_k4125.py
@@ -16,7 +16,7 @@ def test_driver_k4215_basic_operations(res):
     # Test reset
     res.buffer = []
     assert d.reset() is None
-    assert res.buffer == ["*RST"]
+    assert res.buffer == ["*RST", ":ERROR:LAST:CLEAR"]
 
     # Test clear
     res.buffer = []
@@ -26,7 +26,7 @@ def test_driver_k4215_basic_operations(res):
     # Test finalize
     res.buffer = []
     assert d.finalize() is None
-    assert res.buffer == ["*RST"]
+    assert res.buffer == ["*RST", ":ERROR:LAST:CLEAR"]
 
 
 def test_driver_k4215_error_handling(res):

--- a/tests/test_driver_k4125.py
+++ b/tests/test_driver_k4125.py
@@ -1,9 +1,11 @@
 from diode_measurement.driver.k4215 import K4215
+import pytest
 
 from . import res
 
 
-def test_driver_k4215(res):
+def test_driver_k4215_basic_operations(res):
+    """Test basic driver operations."""
     d = K4215(res)
 
     # Test identity
@@ -12,65 +14,405 @@ def test_driver_k4215(res):
     assert res.buffer == ["*IDN?"]
 
     # Test reset
-    res.buffer = ["1"]
+    res.buffer = []
     assert d.reset() is None
-    assert res.buffer == ["*RST", "*OPC?"]
+    assert res.buffer == ["*RST"]
 
     # Test clear
-    res.buffer = ["1"]
+    res.buffer = []
     assert d.clear() is None
-    assert res.buffer == ["BC", "*OPC?"]
+    assert res.buffer == ["BC"]
 
-    # Test error handling
-    res.buffer = ["0,\"No error\""]
+    # Test finalize
+    res.buffer = []
+    assert d.finalize() is None
+    assert res.buffer == ["*RST"]
+
+
+def test_driver_k4215_error_handling(res):
+    """Test error handling functionality."""
+    d = K4215(res)
+
+    # Test no error
+    res.buffer = [""]
     assert d.next_error() == (0, "No error")
-    assert res.buffer == [":ERROR:LAST:GET"]
+    assert res.buffer == [":ERROR:LAST:GET", ":ERROR:LAST:CLEAR"]
 
-    # Test output control
-    res.buffer = ["1"]
-    assert d.get_output_enabled() is True
-    assert res.buffer == [":CVU:OUTPUT?"]
+    # Test error code and text parsing
+    res.buffer = ["KXCI command error. (-992)"]
+    assert d.next_error() == (-992, "KXCI command error")
+    assert res.buffer == [":ERROR:LAST:GET", ":ERROR:LAST:CLEAR"]
 
+    # Test unparseable error format
+    res.buffer = ["Unknown error format with some text"]
+    result = d.next_error()
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result == (-1, "Unknown error format with some text")
+    assert res.buffer == [":ERROR:LAST:GET", ":ERROR:LAST:CLEAR"]
+
+
+def test_driver_k4215_output_control(res):
+    """Test output enable/disable functionality."""
+    d = K4215(res)
+
+    # Test get output enabled - True
     res.buffer = ["1"]
+    # always returns False for K4215, as the command is not implemented
+    # and no querying to the K4215 takes place
+    assert d.get_output_enabled() is False 
+    assert res.buffer == ["1"]
+
+    # Test get output enabled - False
+    # always returns False for K4215, as the command is not implemented
+    # and no querying to the K4215 takes place
+    res.buffer = ["0"]
+    assert d.get_output_enabled() is False
+    assert res.buffer == ["0"]
+
+    # Test set output enabled - True
+    res.buffer = []
     assert d.set_output_enabled(True) is None
-    assert res.buffer == [":CVU:OUTPUT 1", "*OPC?"]
+    assert res.buffer == [":CVU:OUTPUT 1"]
 
-    # Test voltage control
-    res.buffer = ["4.200000E+01"]
-    assert d.get_voltage_level() == 42.0
+    # Test set output enabled - False
+    res.buffer = []
+    assert d.set_output_enabled(False) is None
+    assert res.buffer == [":CVU:OUTPUT 0"]
+
+
+def test_driver_k4215_voltage_level(res):
+    """Test voltage level and range control."""
+    d = K4215(res)
+
+    # Test get voltage level
+    res.buffer = ["2.200000E+01"]
+    assert d.get_voltage_level() == 22.0
     assert res.buffer == [":CVU:DCV?"]
 
-    res.buffer = ["1"]
-    assert d.set_voltage_level(42.0) is None
-    assert res.buffer == [":CVU:DCV 4.200E+01", "*OPC?"]
+    # Test set voltage level
+    res.buffer = []
+    assert d.set_voltage_level(22.0) is None
+    assert res.buffer == [":CVU:DCV 2.200E+01"]
 
-    # Test voltage range
-    res.buffer = ["1"]
-    assert d.set_voltage_range(200.0) is None
-    assert res.buffer == [":CVU:DCV:RANGE 2.000E+02", "*OPC?"]
+    # Test set voltage level with negative value
+    res.buffer = []
+    assert d.set_voltage_level(-5.5) is None
+    assert res.buffer == [":CVU:DCV -5.500E+00"]
 
-    # Test impedance type (string)
-    res.buffer = ["1"]
-    assert d.set_function_impedance_type("CPRP") is None
-    assert res.buffer == [":CVU:MODEL 2", "*OPC?"]
+    # check exception for out-of-range voltage level
+    with pytest.raises(ValueError):
+        d.set_voltage_level(35.0)  # Above max 30V
+    with pytest.raises(ValueError):
+        d.set_voltage_level(-35.0)  # Below min -30V
 
-    # Test impedance type (integer)
-    res.buffer = ["1"]
-    assert d.set_function_impedance_type(3) is None
-    assert res.buffer == [":CVU:MODEL 3", "*OPC?"]
 
-    # Test amplitude voltage
-    res.buffer = ["1"]
-    assert d.set_amplitude_voltage(4.2) is None
-    assert res.buffer == [":CVU:ACV 4.200000E+00", "*OPC?"]
+def test_driver_k4215_voltage_offset(res):
+    """Test voltage offset control."""
+    d = K4215(res)
 
-    # Test amplitude frequency
-    res.buffer = ["1"]
+    # Test get voltage offset
+    res.buffer = ["1.500000E+00"]
+    assert d.get_voltage_offset() == 1.5
+    assert res.buffer == [":CVU:DCV:OFFSET?"]
+
+    # Test set voltage offset
+    res.buffer = []
+    assert d.set_voltage_offset(1.5) is None
+    assert res.buffer == [":CVU:DCV:OFFSET 1.500E+00"]
+
+    # Test set voltage offset with negative value
+    res.buffer = []
+    assert d.set_voltage_offset(-2.0) is None
+    assert res.buffer == [":CVU:DCV:OFFSET -2.000E+00"]
+
+    # check exception for out-of-range voltage level
+    with pytest.raises(ValueError):
+        d.set_voltage_level(35.0)  # Above max 30V
+    with pytest.raises(ValueError):
+        d.set_voltage_level(-35.0)  # Below min -30V
+
+
+def test_driver_k4215_amplitude(res):
+    """Test AC amplitude voltage and frequency control."""
+    d = K4215(res)
+
+    # Test set amplitude voltage
+    res.buffer = []
+    assert d.set_amplitude_voltage(0.2) is None
+    assert res.buffer == [":CVU:ACV 2.000000E-01"]
+
+    # Test set amplitude voltage with small value
+    res.buffer = []
+    assert d.set_amplitude_voltage(0.05) is None
+    assert res.buffer == [":CVU:ACV 5.000000E-02"]
+
+    # check out of range voltage values
+    with pytest.raises(ValueError):
+        d.set_amplitude_voltage(1.5)  # Above max 1V
+    with pytest.raises(ValueError):
+        d.set_amplitude_voltage(0.005)  # Below min 10mV
+
+
+def test_driver_k4215_frequency(res):
+    """Test AC frequency control."""
+    d = K4215(res)
+
+    res.buffer = []
     assert d.set_amplitude_frequency(1.2e3) is None
-    assert res.buffer == [":CVU:FREQ 1200", "*OPC?"]
+    assert res.buffer == [":CVU:FREQ 1200"]
 
-    # Test simple impedance measurement (simplified test)
-    res.buffer = ["1", "1.000000E-01,2.000000E-01"]
-    assert d.measure_impedance() == (0.1, 0.2)
-    # Just verify that some commands were sent, not the exact sequence
-    assert "*ESR?" in res.buffer or ":CVU:MEASZ?" in res.buffer
+    res.buffer = []
+    assert d.set_amplitude_frequency(1e6) is None
+    assert res.buffer == [":CVU:FREQ 1000000"]
+
+    # check out of range frequency values
+    with pytest.raises(ValueError):
+        d.set_amplitude_frequency(5e7)  # Above max 10MHz
+    with pytest.raises(ValueError):
+        d.set_amplitude_frequency(5e2)  # Below min 1kHz
+
+
+def test_driver_k4215_impedance_functions(res):
+    """Test impedance type and measurement functions."""
+    d = K4215(res)
+
+    # Test impedance type with string (CPRP maps to 2)
+    res.buffer = []
+    assert d.set_function_impedance_type("CPRP") is None
+    assert res.buffer == [":CVU:MODEL 2"]
+
+    # Test impedance type with string (CPGP also maps to 2)
+    res.buffer = []
+    assert d.set_function_impedance_type("CPGP") is None
+    assert res.buffer == [":CVU:MODEL 2"]
+
+    # Test impedance type with string (CSRS maps to 3)
+    res.buffer = []
+    assert d.set_function_impedance_type("CSRS") is None
+    assert res.buffer == [":CVU:MODEL 3"]
+
+    # Test impedance type with string (ZTHETA maps to 0)
+    res.buffer = []
+    assert d.set_function_impedance_type("ZTHETA") is None
+    assert res.buffer == [":CVU:MODEL 0"]
+
+    # Test impedance type with string (RPLUSJX maps to 1)
+    res.buffer = []
+    assert d.set_function_impedance_type("RPLUSJX") is None
+    assert res.buffer == [":CVU:MODEL 1"]
+
+    # Test impedance type with string (CPD maps to 4)
+    res.buffer = []
+    assert d.set_function_impedance_type("CPD") is None
+    assert res.buffer == [":CVU:MODEL 4"]
+
+    # Test impedance type with string (CSD maps to 5)
+    res.buffer = []
+    assert d.set_function_impedance_type("CSD") is None
+    assert res.buffer == [":CVU:MODEL 5"]
+
+    # Test impedance type with string (YTHETA maps to 7)
+    res.buffer = []
+    assert d.set_function_impedance_type("YTHETA") is None
+    assert res.buffer == [":CVU:MODEL 7"]
+
+    # Test impedance type with integer
+    res.buffer = []
+    assert d.set_function_impedance_type(3) is None
+    assert res.buffer == [":CVU:MODEL 3"]
+
+    # Test impedance type with invalid string (should default to 2)
+    res.buffer = []
+    assert d.set_function_impedance_type("INVALID") is None
+    assert res.buffer == [":CVU:MODEL 2"]
+
+
+def test_driver_k4215_aperture_control(res):
+    """Test aperture, filter, and delay control."""
+    d = K4215(res)
+
+    # Test default aperture settings - default is aperture=10, filter_factor=1, delay_factor=1
+    res.buffer = []
+    assert d.set_aperture() is None
+    assert res.buffer == [":CVU:SPEED 3,1.000E+00,1.000E+00,1.000E+01"]
+
+    # Test custom aperture settings
+    res.buffer = []
+    assert d.set_aperture(aperture=5, filter_factor=2, delay_factor=3) is None
+    assert res.buffer == [":CVU:SPEED 3,3.000E+00,2.000E+00,5.000E+00"]
+
+    # Test aperture with different values
+    res.buffer = []
+    assert d.set_aperture(aperture=8, filter_factor=4, delay_factor=2) is None
+    assert res.buffer == [":CVU:SPEED 3,2.000E+00,4.000E+00,8.000E+00"]
+
+    # check out of range aperture values
+    with pytest.raises(ValueError):
+        d.set_aperture(aperture=0.001)  # Below min 0.006
+    with pytest.raises(ValueError):
+        d.set_aperture(aperture=11)  # Above max 10.002
+
+    # check out of range filter_factor values
+    with pytest.raises(ValueError):
+        d.set_aperture(filter_factor=-1)  # Below min 0
+    with pytest.raises(ValueError):
+        d.set_aperture(filter_factor=800)  # Above max 707
+
+    # check out of range delay_factor values
+    with pytest.raises(ValueError):
+        d.set_aperture(delay_factor=-1)  # Below min 0
+    with pytest.raises(ValueError):
+        d.set_aperture(delay_factor=150)  # Above max 100
+
+
+def test_driver_k4215_correction_functions(res):
+    """Test correction and cable length functions."""
+    d = K4215(res)
+
+    # Test correction - all disabled (format: open,short,load)
+    res.buffer = []
+    assert d.set_correction() is None
+    assert res.buffer == [":CVU:CORRECT 0,0,0"]
+
+    # Test correction - open enabled
+    res.buffer = []
+    assert d.set_correction(open_state=True) is None
+    assert res.buffer == [":CVU:CORRECT 1,0,0"]
+
+    # Test correction - short enabled
+    res.buffer = []
+    assert d.set_correction(short_state=True) is None
+    assert res.buffer == [":CVU:CORRECT 0,1,0"]
+
+    # Test correction - load enabled
+    res.buffer = []
+    assert d.set_correction(load_state=True) is None
+    assert res.buffer == [":CVU:CORRECT 0,0,1"]
+
+    # Test correction - multiple enabled
+    res.buffer = []
+    assert d.set_correction(open_state=True, short_state=True) is None
+    assert res.buffer == [":CVU:CORRECT 1,1,0"]
+
+
+
+def test_driver_k4215_correction_length_validation(res):
+    """Test cable length correction with validation."""
+    d = K4215(res)
+
+    # Test valid cable lengths
+    valid_lengths = [0, 1.5, 3.0]
+    for length in valid_lengths:
+        res.buffer = []
+        assert d.set_correction_length(length) is None
+        assert res.buffer == [f":CVU:LENGTH {length:.1f}"]
+
+    # test invalid cable length
+    with pytest.raises(ValueError):
+        d.set_correction_length(5)
+    with pytest.raises(ValueError):
+        d.set_correction_length(-1)
+
+
+def test_driver_k4215_aci_range(res):
+    """Test ACI range setting."""
+    d = K4215(res)
+
+    for aci_range in [0, 1e-6, 30e-6, 1e-3]:
+        res.buffer = []
+        assert d.set_aci_range(aci_range) is None
+        assert res.buffer == [f":CVU:ACZ:RANGE {aci_range:.6E}"]
+
+    # check invalid ACI range values
+    with pytest.raises(ValueError):
+        d.set_aci_range(2e-3)  # Above max 1mA
+    with pytest.raises(ValueError):
+        d.set_aci_range(0.5e-6)  # Below min 1uA
+
+
+def test_driver_k4215_impedance_measurement(res):
+    """Test impedance measurement functionality."""
+    d = K4215(res)
+
+    # Test successful impedance measurement - _fetch() directly queries :CVU:MEASZ?
+    res.buffer = ["1.000000E-01,2.000000E-01"]
+    result = d.measure_impedance()
+    assert result == (0.1, 0.2)
+    # Check that measurement command was sent
+    assert res.buffer == [":CVU:MEASZ?"]
+
+    # Test impedance measurement with different values
+    res.buffer = ["5.500000E-03,-1.200000E-02"]
+    result = d.measure_impedance()
+    assert result == (0.0055, -0.012)
+    assert res.buffer == [":CVU:MEASZ?"]
+
+
+def test_driver_k4215_external_bias_tee(res):
+    """Test external bias tee functionality."""
+    d = K4215(res)
+
+    # Test external bias tee configuration
+    res.buffer = []  # Need enough responses for all the _write calls
+    d._external_bias_tee_enabled = True
+    d._enable_bias_tee_dc_voltage()
+    expected_commands = [
+        ":CVU:CONFIG:ACVHI 1",
+        ":CVU:CONFIG:DCVHI 1",
+        ":CVU:DCV:OFFSET -10",
+        ":CVU:DCV -10",
+    ]
+    assert res.buffer == expected_commands
+
+    # Test that setting voltage level raises error when bias tee enabled
+    d._external_bias_tee_enabled = True
+    with pytest.raises(RuntimeError):
+        d.set_voltage_level(5.0)
+
+    with pytest.raises(RuntimeError):
+        d.set_voltage_offset(2.0)
+
+
+def test_driver_k4215_abstract_methods(res):
+    """Test abstract method implementations."""
+    d = K4215(res)
+
+    # Test compliance_tripped (always returns False for K4215)
+    assert d.compliance_tripped() is False
+
+    # Test measure_i (not supported, returns 0.0)
+    assert d.measure_i() == 0.0
+
+    # Test measure_iv (not supported, returns 0.0, 0.0)
+    assert d.measure_iv() == (0.0, 0.0)
+
+    # Test set_current_compliance_level (no-op for K4215)
+    assert d.set_current_compliance_level(0.1) is None
+
+
+def test_driver_k4215_default_configuration(res):
+    """Test comprehensive configuration with all options."""
+    d = K4215(res)
+
+    res.buffer = [] 
+    options = {"voltage": 0.1, "frequency": 100000.0}
+    d.configure(options)
+
+    assert ":CVU:MODE 0" in res.buffer  # CVU mode set
+    assert ":CVU:MODEL 2" in res.buffer  # Default CPRP function type
+    assert ":CVU:ACV 1.000000E-01" in res.buffer  # AC voltage
+    assert ":CVU:FREQ 100000" in res.buffer  # Frequency
+
+
+
+def test_driver_k4215_fetch_functionality(res):
+    """Test _fetch method for measurement operations."""
+    d = K4215(res)
+
+    # _fetch directly queries :CVU:MEASZ?
+    res.buffer = ["1.000000E-01,2.000000E-01"]
+    result = d._fetch(timeout=1.0, interval=0.1)
+    assert result == "1.000000E-01,2.000000E-01"
+    assert res.buffer == [":CVU:MEASZ?"]
+

--- a/tests/test_driver_k4125.py
+++ b/tests/test_driver_k4125.py
@@ -86,9 +86,11 @@ def test_driver_k4215_voltage_level(res):
     d = K4215(res)
 
     # Test get voltage level
+    # as this is not implemented by the instrument, it always returns 0.0
+    # and does not query the instrument
     res.buffer = ["2.200000E+01"]
-    assert d.get_voltage_level() == 22.0
-    assert res.buffer == [":CVU:DCV?"]
+    assert d.get_voltage_level() == 0.0
+    assert res.buffer == ["2.200000E+01"]
 
     # Test set voltage level
     res.buffer = []
@@ -112,9 +114,11 @@ def test_driver_k4215_voltage_offset(res):
     d = K4215(res)
 
     # Test get voltage offset
+    # as this is not implemented by the instrument, it always returns 0.0
+    # and does not query the instrument
     res.buffer = ["1.500000E+00"]
-    assert d.get_voltage_offset() == 1.5
-    assert res.buffer == [":CVU:DCV:OFFSET?"]
+    assert d.get_voltage_offset() == 0.0
+    assert res.buffer == ["1.500000E+00"]
 
     # Test set voltage offset
     res.buffer = []

--- a/tests/test_driver_k4125.py
+++ b/tests/test_driver_k4125.py
@@ -60,7 +60,7 @@ def test_driver_k4215_output_control(res):
     res.buffer = ["1"]
     # always returns False for K4215, as the command is not implemented
     # and no querying to the K4215 takes place
-    assert d.get_output_enabled() is False 
+    assert d.get_output_enabled() is False
     assert res.buffer == ["1"]
 
     # Test get output enabled - False
@@ -300,7 +300,6 @@ def test_driver_k4215_correction_functions(res):
     assert res.buffer == [":CVU:CORRECT 1,1,0"]
 
 
-
 def test_driver_k4215_correction_length_validation(res):
     """Test cable length correction with validation."""
     d = K4215(res)
@@ -399,7 +398,7 @@ def test_driver_k4215_default_configuration(res):
     """Test comprehensive configuration with all options."""
     d = K4215(res)
 
-    res.buffer = [] 
+    res.buffer = []
     options = {"voltage": 0.1, "frequency": 100000.0}
     d.configure(options)
 
@@ -407,7 +406,6 @@ def test_driver_k4215_default_configuration(res):
     assert ":CVU:MODEL 2" in res.buffer  # Default CPRP function type
     assert ":CVU:ACV 1.000000E-01" in res.buffer  # AC voltage
     assert ":CVU:FREQ 100000" in res.buffer  # Frequency
-
 
 
 def test_driver_k4215_fetch_functionality(res):
@@ -419,4 +417,3 @@ def test_driver_k4215_fetch_functionality(res):
     result = d._fetch(timeout=1.0, interval=0.1)
     assert result == "1.000000E-01,2.000000E-01"
     assert res.buffer == [":CVU:MEASZ?"]
-

--- a/tests/test_driver_k4125.py
+++ b/tests/test_driver_k4125.py
@@ -1,0 +1,76 @@
+from diode_measurement.driver.k4215 import K4215
+
+from . import res
+
+
+def test_driver_k4215(res):
+    d = K4215(res)
+
+    # Test identity
+    res.buffer = ["KEITHLEY INSTRUMENTS,KI4200A,1489223,V1.14"]
+    assert d.identity() == "KEITHLEY INSTRUMENTS,KI4200A,1489223,V1.14"
+    assert res.buffer == ["*IDN?"]
+
+    # Test reset
+    res.buffer = ["1"]
+    assert d.reset() is None
+    assert res.buffer == ["*RST", "*OPC?"]
+
+    # Test clear
+    res.buffer = ["1"]
+    assert d.clear() is None
+    assert res.buffer == ["BC", "*OPC?"]
+
+    # Test error handling
+    res.buffer = ["0,\"No error\""]
+    assert d.next_error() == (0, "No error")
+    assert res.buffer == [":ERROR:LAST:GET"]
+
+    # Test output control
+    res.buffer = ["1"]
+    assert d.get_output_enabled() is True
+    assert res.buffer == [":CVU:OUTPUT?"]
+
+    res.buffer = ["1"]
+    assert d.set_output_enabled(True) is None
+    assert res.buffer == [":CVU:OUTPUT 1", "*OPC?"]
+
+    # Test voltage control
+    res.buffer = ["4.200000E+01"]
+    assert d.get_voltage_level() == 42.0
+    assert res.buffer == [":CVU:DCV?"]
+
+    res.buffer = ["1"]
+    assert d.set_voltage_level(42.0) is None
+    assert res.buffer == [":CVU:DCV 4.200E+01", "*OPC?"]
+
+    # Test voltage range
+    res.buffer = ["1"]
+    assert d.set_voltage_range(200.0) is None
+    assert res.buffer == [":CVU:DCV:RANGE 2.000E+02", "*OPC?"]
+
+    # Test impedance type (string)
+    res.buffer = ["1"]
+    assert d.set_function_impedance_type("CPRP") is None
+    assert res.buffer == [":CVU:MODEL 2", "*OPC?"]
+
+    # Test impedance type (integer)
+    res.buffer = ["1"]
+    assert d.set_function_impedance_type(3) is None
+    assert res.buffer == [":CVU:MODEL 3", "*OPC?"]
+
+    # Test amplitude voltage
+    res.buffer = ["1"]
+    assert d.set_amplitude_voltage(4.2) is None
+    assert res.buffer == [":CVU:ACV 4.200000E+00", "*OPC?"]
+
+    # Test amplitude frequency
+    res.buffer = ["1"]
+    assert d.set_amplitude_frequency(1.2e3) is None
+    assert res.buffer == [":CVU:FREQ 1200", "*OPC?"]
+
+    # Test simple impedance measurement (simplified test)
+    res.buffer = ["1", "1.000000E-01,2.000000E-01"]
+    assert d.measure_impedance() == (0.1, 0.2)
+    # Just verify that some commands were sent, not the exact sequence
+    assert "*ESR?" in res.buffer or ":CVU:MEASZ?" in res.buffer


### PR DESCRIPTION
The necessary commands to use the K4215-CVU for C-V measurements have been implemented.
As this LCR meter works slightly differently to other LCR meters, the `K4215Panel` has been adapted to reflect this.

If the external Keithley 2600-RBT-200 or 2650-RBT-3K bias tees are used, -10V is applied on the CVUHI and CVULO terminals of the CVU. This can be enabled by setting the "External Bias Tee" checkbox. In this mode, no changes to the DC level of the CVU are permitted.

Gettter commands for the CVU output, the DC level and offset are unfortunately not supported by the instrument.
Instead, placeholder functions always returning 0 have been used.
