### PR TITLE
Missing icons in pyinstaller single file builds

### DIFF
--- a/diode_measurement/application.py
+++ b/diode_measurement/application.py
@@ -19,6 +19,17 @@ PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
 ASSETS_PATH = os.path.join(PACKAGE_PATH, "assets")
 
 
+def create_icon(filename: str) -> QtGui.QIcon:
+    """Load icon into memory and create a QIcon, this prevents missing icons for
+    pyinstaller single file builds.
+    """
+    with open(os.path.join(ASSETS_PATH, "icons", filename), "rb") as f:
+        icon_bytes = f.read()
+    pixmap = QtGui.QPixmap()
+    pixmap.loadFromData(icon_bytes)
+    return QtGui.QIcon(pixmap)
+
+
 class Application(QtWidgets.QApplication):
 
     def __init__(self):
@@ -28,9 +39,7 @@ class Application(QtWidgets.QApplication):
         self.setApplicationDisplayName(f"Diode Measurement {__version__}")
         self.setOrganizationName("HEPHY")
         self.setOrganizationDomain("hephy.at")
-
-        icon = QtGui.QIcon(os.path.join(ASSETS_PATH, "icons", "diode-measurement.svg"))
-        self.setWindowIcon(icon)
+        self.setWindowIcon(create_icon("diode-measurement.svg"))
 
     def bootstrap(self):
         # Initialize settings


### PR DESCRIPTION
Running a PyInstaller single file executable on Windows suffers from missing icons after some time.

This is caused by the self extracting executable that unpacks the application files into a temporary directory and is loading assets from this location. Windows keeps deleting unlocked temporary files after a configurable number of hours, so icons will disappear after a certain time (Qt detects the missing file and frees the memory).

Proposed quick fix: load the icon data into memory on startup and create a QIcon from the raw memory to prevent linking it to the filesystem.

Future fix: migrate to PySide6 and use the Qt resource system (qrc) to generate an assets module.