### PR TITLE
Broken measure_iv() for K6517B

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Broken `measure_iv` method for K6517b (#120).
+
 ## [0.22.0] - 2025-09-22
 
 ### Added

--- a/diode_measurement/driver/k2400.py
+++ b/diode_measurement/driver/k2400.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 from .driver import SourceMeter, handle_exception
 
@@ -9,7 +9,7 @@ class K2400(SourceMeter):
 
     def __init__(self, resource) -> None:
         super().__init__(resource)
-        self._format_element = None
+        self._format_element: Optional[str] = None
 
     def identity(self) -> str:
         return self._query("*IDN?")

--- a/diode_measurement/driver/k6517b.py
+++ b/diode_measurement/driver/k6517b.py
@@ -95,7 +95,7 @@ class K6517B(Electrometer):
         raise RuntimeError(f"Electrometer reading timeout, exceeded {timeout:G} s")
 
     def measure_iv(self) -> Tuple[float, float]:
-        i = self.measure_i(), float("nan")  # TODO
+        return self.measure_i(), float("nan")  # TODO
 
     def set_format_elements(self, elements: List[str]) -> None:
         value = ",".join(elements)


### PR DESCRIPTION
fixes broken measure_iv() for K6517B, fixed type hint for K2400