### PR TITLE
Broken disable TCP server on error

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- Broken disable TCP server on error (#121).
+
 ## [0.22.0] - 2025-09-22
 
 ### Added

--- a/diode_measurement/plugins/tcpserver.py
+++ b/diode_measurement/plugins/tcpserver.py
@@ -207,6 +207,7 @@ class TCPServerPlugin(Plugin, QtCore.QObject):
         self._messageCacheLock = threading.RLock()
         self._messageTimer = QtCore.QTimer()
         self._messageTimer.timeout.connect(self.appendCachedMessages)
+        self.failed.connect(lambda _: self.rpcWidget.setServerEnabled(False))  # disable on error
 
     def install(self, context):
         self.failed.connect(context.handleException)
@@ -318,7 +319,6 @@ class TCPServerPlugin(Plugin, QtCore.QObject):
                 server.serve_forever()
         except Exception as exc:
             logger.exception(exc)
-            self.setServerEnabled(False)
             self.failed.emit(exc)
         finally:
             logger.info("TCP stopped %s:%s", hostname, port)


### PR DESCRIPTION
Fixes broken disable TCP server enable checkbox on error (preventing from infinite reconnect loop).