### PR TITLE
Replace Dict, List, Tuple annotations with built-in types

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Replaced `Dict`, `List`, `Tuple` annotations with Python 3.9+ built-in types (#122).
+
 ## [0.22.0] - 2025-09-22
 
 ### Added

--- a/diode_measurement/cache.py
+++ b/diode_measurement/cache.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Any, Dict, Iterator
+from typing import Any, Iterator
 
 __all__ = ["Cache"]
 
@@ -9,7 +9,7 @@ class Cache:
 
     def __init__(self) -> None:
         self._lock: threading.RLock = threading.RLock()
-        self._items: Dict[str, Any] = {}
+        self._items: dict[str, Any] = {}
 
     def __enter__(self) -> "Cache":
         self._lock.acquire()
@@ -25,7 +25,7 @@ class Cache:
     def get(self, key: str, default=None):
         return self._items.get(key, default)
 
-    def update(self, items: Dict[str, Any]) -> None:
+    def update(self, items: dict[str, Any]) -> None:
         self._items.update(items)
 
     def clear(self) -> None:

--- a/diode_measurement/controller.py
+++ b/diode_measurement/controller.py
@@ -7,7 +7,7 @@ import threading
 import time
 
 from datetime import datetime
-from typing import Any, Dict, List, Iterator, Optional
+from typing import Any, Iterator, Optional
 
 from PyQt5 import QtCore, QtWidgets
 
@@ -295,8 +295,8 @@ class Controller(QtCore.QObject):
             snapshot["temperature"] = self.cache.get("dmm_temperature")
             return snapshot
 
-    def prepareState(self) -> Dict[str, Any]:
-        state: Dict[str, Any] = {}
+    def prepareState(self) -> dict[str, Any]:
+        state: dict[str, Any] = {}
 
         state["sample"] = self.view.generalWidget.sampleName()
         state["measurement_type"] = self.view.generalWidget.currentMeasurement().get("type")
@@ -314,7 +314,7 @@ class Controller(QtCore.QObject):
         state["continue_in_compliance"] = self.view.generalWidget.isContinueInCompliance()
         state["waiting_time_continuous"] = self.view.generalWidget.waitingTimeContinuous()
 
-        roles: Dict[str, Any] = state.setdefault("roles", {})
+        roles: dict[str, Any] = state.setdefault("roles", {})
 
         for role in self.view.roles():
             key = role.name().lower()
@@ -1069,7 +1069,7 @@ class IVPlotsController(QtCore.QObject):
         if fit:
             self.ivPlotWidget.fit()
 
-    def onLoadIVReadings(self, readings: List[dict]) -> None:
+    def onLoadIVReadings(self, readings: list[dict]) -> None:
         smuPoints = []
         smu2Points = []
         elmPoints = []
@@ -1135,11 +1135,11 @@ class IVPlotsController(QtCore.QObject):
         if fit:
             self.itPlotWidget.fit()
 
-    def onLoadItReadings(self, readings: List[dict]) -> None:
-        smuPoints: List[QtCore.QPointF] = []
-        smu2Points: List[QtCore.QPointF] = []
-        elmPoints: List[QtCore.QPointF] = []
-        elm2Points: List[QtCore.QPointF] = []
+    def onLoadItReadings(self, readings: list[dict]) -> None:
+        smuPoints: list[QtCore.QPointF] = []
+        smu2Points: list[QtCore.QPointF] = []
+        elmPoints: list[QtCore.QPointF] = []
+        elm2Points: list[QtCore.QPointF] = []
         widget = self.itPlotWidget
         widget.clear()
         for reading in readings:
@@ -1231,8 +1231,8 @@ class CVPlotsController(QtCore.QObject):
         if math.isfinite(voltage) and math.isfinite(c2_lcr):
             self.cv2PlotWidget.append("lcr", voltage, c2_lcr)
 
-    def onLoadCVReadings(self, readings: List[dict]) -> None:
-        lcrPoints: List[QtCore.QPointF] = []
+    def onLoadCVReadings(self, readings: list[dict]) -> None:
+        lcrPoints: list[QtCore.QPointF] = []
         widget = self.cvPlotWidget
         widget.clear()
         for reading in readings:
@@ -1245,8 +1245,8 @@ class CVPlotsController(QtCore.QObject):
         widget.series.get("lcr").replace(lcrPoints)
         widget.fit()
 
-    def onLoadCV2Readings(self, readings: List[dict]) -> None:
-        lcr2Points: List[QtCore.QPointF] = []
+    def onLoadCV2Readings(self, readings: list[dict]) -> None:
+        lcr2Points: list[QtCore.QPointF] = []
         widget = self.cv2PlotWidget
         widget.clear()
         for reading in readings:

--- a/diode_measurement/driver/__init__.py
+++ b/diode_measurement/driver/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from .driver import Driver
 
 # Drivers
 from .k237 import K237
@@ -16,7 +16,7 @@ from .brandbox import BrandBox
 
 __all__ = ["driver_factory"]
 
-DRIVERS: Dict[str, type] = {
+DRIVER_REGISTRY: dict[str, type[Driver]] = {
     "K237": K237,
     "K595": K595,
     "K2410": K2410,
@@ -32,9 +32,9 @@ DRIVERS: Dict[str, type] = {
 }
 
 
-def driver_factory(model: str) -> type:
+def driver_factory(model: str) -> type[Driver]:
     """Return driver class referenced by model."""
-    driver = DRIVERS.get(model)
+    driver = DRIVER_REGISTRY.get(model)
     if driver is None:
-        raise ValueError(f"No such driver: {model}")
+        raise KeyError(f"No such driver: {model}")
     return driver

--- a/diode_measurement/driver/a4284a.py
+++ b/diode_measurement/driver/a4284a.py
@@ -1,5 +1,4 @@
 import time
-from typing import Tuple
 
 from .driver import LCRMeter, handle_exception
 
@@ -17,7 +16,7 @@ class A4284A(LCRMeter):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')
@@ -81,10 +80,10 @@ class A4284A(LCRMeter):
     def measure_i(self) -> float:
         return 0.0
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         return 0.0, 0.0
 
-    def measure_impedance(self) -> Tuple[float, float]:
+    def measure_impedance(self) -> tuple[float, float]:
         result = self._fetch().split(",")
         try:
             return float(result[0]), float(result[1])

--- a/diode_measurement/driver/brandbox.py
+++ b/diode_measurement/driver/brandbox.py
@@ -1,21 +1,21 @@
 import re
 
-from typing import Dict, List, Tuple, Optional
+from typing import Optional
 
 from .driver import SwitchingMatrix, handle_exception
 
 __all__ = ["BrandBox"]
 
-ERROR_MESSAGES: Dict[int, str] = {
+ERROR_MESSAGES: dict[int, str] = {
     99: "Invalid command"
 }
 
 
-def split_channels(channels: str) -> List[str]:
+def split_channels(channels: str) -> list[str]:
     return [channel.strip() for channel in channels.split(',') if channel.strip()]
 
 
-def join_channels(channels: List[str]) -> str:
+def join_channels(channels: list[str]) -> str:
     return ','.join([format(channel).strip() for channel in channels])
 
 
@@ -45,7 +45,7 @@ class BrandBox(SwitchingMatrix):
         self._error_queue.clear()
         self._write("*CLS")  # NOTE: closes IV-Mode channels!
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code = 0
         if self._error_queue:
             code = self._error_queue.pop(0)

--- a/diode_measurement/driver/driver.py
+++ b/diode_measurement/driver/driver.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +39,7 @@ class Driver(ABC):
         ...
 
     @abstractmethod
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         ...
 
     @abstractmethod
@@ -83,7 +82,7 @@ class SourceMeter(Driver):
         ...
 
     @abstractmethod
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         ...
 
 
@@ -101,7 +100,7 @@ class Electrometer(SourceMeter):
 class LCRMeter(SourceMeter):
 
     @abstractmethod
-    def measure_impedance(self) -> Tuple[float, float]:
+    def measure_impedance(self) -> tuple[float, float]:
         ...
 
 

--- a/diode_measurement/driver/e4980a.py
+++ b/diode_measurement/driver/e4980a.py
@@ -1,5 +1,4 @@
 import time
-from typing import Tuple
 
 from .driver import LCRMeter, handle_exception
 
@@ -17,7 +16,7 @@ class E4980A(LCRMeter):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')
@@ -83,10 +82,10 @@ class E4980A(LCRMeter):
     def measure_i(self) -> float:
         return 0.0
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         return 0.0, 0.0
 
-    def measure_impedance(self) -> Tuple[float, float]:
+    def measure_impedance(self) -> tuple[float, float]:
         result = self._fetch().split(",")
         try:
             return float(result[0]), float(result[1])

--- a/diode_measurement/driver/k237.py
+++ b/diode_measurement/driver/k237.py
@@ -1,6 +1,5 @@
 import time
 import logging
-from typing import Tuple
 
 from .driver import SourceMeter, handle_exception
 
@@ -51,7 +50,7 @@ class K237(SourceMeter):
     def clear(self) -> None:
         self.resource.clear()
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         result = self._query("U1X").strip()[3:]
         for index, value in enumerate(result):
             if value == "1":
@@ -93,7 +92,7 @@ class K237(SourceMeter):
         self._write("G4,2,0X")
         return float(self._query("X"))
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         i = self.measure_i()
         v = self.get_voltage_level()  # not possible in function VOLT
         return i, v

--- a/diode_measurement/driver/k2400.py
+++ b/diode_measurement/driver/k2400.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from .driver import SourceMeter, handle_exception
 
 __all__ = ["K2400"]
@@ -20,7 +18,7 @@ class K2400(SourceMeter):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         result = self._query(":SYST:ERR?")
         try:
             code, message = result.split(",")
@@ -85,7 +83,7 @@ class K2400(SourceMeter):
         _, v = self.measure_iv()
         return v
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         if self._format_element != "VOLT,CURR":
             self._write(":FORM:ELEM VOLT,CURR")
             self._format_element = "VOLT,CURR"

--- a/diode_measurement/driver/k2470.py
+++ b/diode_measurement/driver/k2470.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from .driver import SourceMeter, handle_exception
 
 __all__ = ["K2470"]
@@ -16,7 +14,7 @@ class K2470(SourceMeter):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')
@@ -71,7 +69,7 @@ class K2470(SourceMeter):
     def measure_v(self) -> float:
         return float(self._query(":MEAS:VOLT?"))
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         i = self.measure_i()  # no concurrent measurements possible?
         v = self.measure_v()
         return i, v

--- a/diode_measurement/driver/k2657a.py
+++ b/diode_measurement/driver/k2657a.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from .driver import SourceMeter, handle_exception
 
 __all__ = ["K2657A"]
@@ -16,7 +14,7 @@ class K2657A(SourceMeter):
     def clear(self) -> None:
         self._write("status.reset()")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message, *_ = self._print("errorqueue.next()").split("\t")
         code = int(float(code))
         message = message.strip().strip('"')
@@ -68,7 +66,7 @@ class K2657A(SourceMeter):
     def measure_v(self) -> float:
         return float(self._print("smua.measure.v()"))
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         i = self.measure_i()  # TODO print(smua.measure.iv())
         v = self.measure_v()
         return i, v

--- a/diode_measurement/driver/k2700.py
+++ b/diode_measurement/driver/k2700.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from .driver import DMM, handle_exception
 
 __all__ = ["K2700"]
@@ -16,7 +14,7 @@ class K2700(DMM):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')

--- a/diode_measurement/driver/k4215.py
+++ b/diode_measurement/driver/k4215.py
@@ -1,5 +1,4 @@
 import time
-from typing import Tuple
 
 from .driver import LCRMeter, handle_exception
 
@@ -23,7 +22,7 @@ class K4215(LCRMeter):
     def clear(self) -> None:
         self._write("BC")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         """Get the next error from the instrument's error queue."""
         # KXCI uses :ERROR:LAST:GET to retrieve the last error
         response = self._query(":ERROR:LAST:GET")
@@ -154,7 +153,7 @@ class K4215(LCRMeter):
             time.sleep(interval)
         raise RuntimeError(f"LCR reading timeout, exceeded {timeout:G} s")
 
-    def measure_impedance(self) -> Tuple[float, float]:
+    def measure_impedance(self) -> tuple[float, float]:
         result = self._fetch().split(",")
         try:
             return float(result[0]), float(result[1])
@@ -305,7 +304,7 @@ class K4215(LCRMeter):
         """Measure current - not supported on K4215."""
         return 0.0
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         """Measure current and voltage - not supported on K4215."""
         return 0.0, 0.0
 

--- a/diode_measurement/driver/k595.py
+++ b/diode_measurement/driver/k595.py
@@ -1,6 +1,5 @@
 import math
 import time
-from typing import Tuple
 
 from .driver import LCRMeter, handle_exception
 
@@ -30,7 +29,7 @@ class K595(LCRMeter):
     def clear(self) -> None:
         self.resource.clear()
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         result = self._query("U1X")[3:]
         for index, value in enumerate(result):
             if value == "1":
@@ -71,10 +70,10 @@ class K595(LCRMeter):
         self._write("G1X")
         return float(self._query("X").split(",")[0])
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         return self.measure_i(), float("nan")  # TODO
 
-    def measure_impedance(self) -> Tuple[float, float]:
+    def measure_impedance(self) -> tuple[float, float]:
         self._write("F0X")
         self._write("G1X")
         return float(self._query("X").split(",")[0]), math.nan

--- a/diode_measurement/driver/k6514.py
+++ b/diode_measurement/driver/k6514.py
@@ -1,5 +1,4 @@
 import time
-from typing import List, Tuple
 
 from .driver import Electrometer, handle_exception
 
@@ -17,7 +16,7 @@ class K6514(Electrometer):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')
@@ -91,10 +90,10 @@ class K6514(Electrometer):
             time.sleep(interval)
         raise RuntimeError(f"Electrometer reading timeout, exceeded {timeout:G} s")
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         return self.measure_i(), float("nan")  # TODO
 
-    def set_format_elements(self, elements: List[str]) -> None:
+    def set_format_elements(self, elements: list[str]) -> None:
         value = ",".join(elements)
         self._write(f":FORM:ELEM {value}")
 

--- a/diode_measurement/driver/k6517b.py
+++ b/diode_measurement/driver/k6517b.py
@@ -1,5 +1,4 @@
 import time
-from typing import List, Tuple
 
 from .driver import Electrometer, handle_exception
 
@@ -17,7 +16,7 @@ class K6517B(Electrometer):
     def clear(self) -> None:
         self._write("*CLS")
 
-    def next_error(self) -> Tuple[int, str]:
+    def next_error(self) -> tuple[int, str]:
         code, message = self._query(":SYST:ERR?").split(",")
         code = int(code)
         message = message.strip().strip('"')
@@ -94,10 +93,10 @@ class K6517B(Electrometer):
             time.sleep(interval)
         raise RuntimeError(f"Electrometer reading timeout, exceeded {timeout:G} s")
 
-    def measure_iv(self) -> Tuple[float, float]:
+    def measure_iv(self) -> tuple[float, float]:
         i = self.measure_i(), float("nan")  # TODO
 
-    def set_format_elements(self, elements: List[str]) -> None:
+    def set_format_elements(self, elements: list[str]) -> None:
         value = ",".join(elements)
         self._write(f":FORM:ELEM {value}")
 

--- a/diode_measurement/measurement/__init__.py
+++ b/diode_measurement/measurement/__init__.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import time
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from ..resource import Resource, AutoReconnectResource
 from ..driver import driver_factory
@@ -15,13 +15,13 @@ __all__ = ["Measurement", "RangeMeasurement"]
 
 logger = logging.getLogger(__name__)
 
-ReadingType = Dict[str, Any]
+ReadingType = dict[str, Any]
 
 
 class EventHandler:
 
     def __init__(self) -> None:
-        self.handlers: List[Callable] = []
+        self.handlers: list[Callable] = []
 
     def subscribe(self, handler: Callable) -> None:
         self.handlers.append(handler)
@@ -36,8 +36,8 @@ class Measurement:
     def __init__(self, state: State) -> None:
         super().__init__()
         self.state: State = state
-        self.instruments: Dict = {}
-        self._instruments: Dict = {}
+        self.instruments: dict = {}
+        self._instruments: dict = {}
         self.started_event: EventHandler = EventHandler()
         self.finished_event: EventHandler = EventHandler()
         self.failed_event: EventHandler = EventHandler()

--- a/diode_measurement/measurement/cv.py
+++ b/diode_measurement/measurement/cv.py
@@ -2,7 +2,7 @@ import logging
 import math
 import time
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from ..utils import inverse_square
 

--- a/diode_measurement/measurement/iv.py
+++ b/diode_measurement/measurement/iv.py
@@ -3,7 +3,7 @@ import math
 import time
 import threading
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from ..estimate import Estimate
 

--- a/diode_measurement/measurement/iv_bias.py
+++ b/diode_measurement/measurement/iv_bias.py
@@ -3,7 +3,7 @@ import math
 import time
 import threading
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from ..estimate import Estimate
 

--- a/diode_measurement/plugins/__init__.py
+++ b/diode_measurement/plugins/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List
+from typing import Any
 
 __all__ = ["Plugin", "PluginRegistry"]
 
@@ -21,7 +21,7 @@ class PluginRegistry:
 
     def __init__(self, context: Any) -> None:
         self._context: Any = context
-        self._plugins: List[Plugin] = []
+        self._plugins: list[Plugin] = []
 
     def install(self, plugin: Plugin) -> None:
         """Install a plugin."""
@@ -31,7 +31,7 @@ class PluginRegistry:
         logger.debug("Installing plugin %s... done.", repr(type(plugin).__name__))
 
     @property
-    def plugins(self) -> List[Plugin]:
+    def plugins(self) -> list[Plugin]:
         """Return list of installed plugins."""
         return [plugin for plugin in self._plugins]
 

--- a/diode_measurement/plugins/tcpserver.py
+++ b/diode_measurement/plugins/tcpserver.py
@@ -10,7 +10,7 @@ import socketserver
 import threading
 import time
 
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 from PyQt5 import QtCore, QtWidgets
 
@@ -44,7 +44,7 @@ class RPCHandler:
         self.dispatcher["state"] = self.on_state
         self.manager = jsonrpc.JSONRPCResponseManager()
 
-    def handle(self, request) -> Dict[str, Any]:
+    def handle(self, request) -> dict[str, Any]:
         return self.manager.handle(request, self.dispatcher)
 
     def on_start(self, reset: bool = None, continuous: bool = None,
@@ -54,7 +54,7 @@ class RPCHandler:
                  compliance: float = None,
                  waiting_time_continuous: float = None) -> None:
         with self.controller.rpc_params:
-            rpc_params: Dict[str, Union[None, int, float, str]] = {}
+            rpc_params: dict[str, Union[None, int, float, str]] = {}
             if reset is not None:
                 rpc_params["reset"] = reset
             if continuous is not None:
@@ -83,7 +83,7 @@ class RPCHandler:
                           waiting_time: float = 1.0) -> None:
         self.controller.requestChangeVoltage.emit(end_voltage, step_voltage, waiting_time)
 
-    def on_state(self) -> Dict[str, Union[None, int, float, str]]:
+    def on_state(self) -> dict[str, Union[None, int, float, str]]:
         return json_dict(self.controller.snapshot())
 
 

--- a/diode_measurement/utils.py
+++ b/diode_measurement/utils.py
@@ -2,7 +2,7 @@ import os
 import re
 import pint
 
-from typing import Iterable, Tuple
+from typing import Iterable
 
 import pyvisa
 
@@ -19,7 +19,7 @@ __all__ = [
 ureg = pint.UnitRegistry()
 
 
-def get_resource(resource_name: str) -> Tuple[str, str]:
+def get_resource(resource_name: str) -> tuple[str, str]:
     """Create valid VISA resource name for short descriptors."""
     resource_name = resource_name.strip()
 
@@ -53,7 +53,7 @@ def safe_filename(filename: str) -> str:
     return re.sub(r"[^a-zA-Z0-9\_\/\.\-]+", "_", filename)
 
 
-def auto_scale(value: float) -> Tuple[float, str, str]:
+def auto_scale(value: float) -> tuple[float, str, str]:
     scales = (
         (1e+24, "Y", "yotta"),
         (1e+21, "Z", "zetta"),
@@ -98,9 +98,9 @@ def format_switch(value: bool) -> str:
     return {False: "OFF", True: "ON"}.get(value) or "---"
 
 
-def limits(iterable: Iterable) -> Tuple:
+def limits(iterable: Iterable) -> tuple:
     """Calculate limits of 2D point series."""
-    limits: Tuple = tuple()
+    limits: tuple = tuple()
     for x, y in iterable:
         if not limits:
             limits = (x, x, y, y)

--- a/diode_measurement/view/logwindow.py
+++ b/diode_measurement/view/logwindow.py
@@ -1,7 +1,7 @@
 import html
 import logging
 import threading
-from typing import Callable, List
+from typing import Callable
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -22,13 +22,13 @@ class RecordsQueue:
 
     def __init__(self) -> None:
         self.lock = threading.RLock()
-        self.records: List[logging.LogRecord] = []
+        self.records: list[logging.LogRecord] = []
 
     def append(self, record: logging.LogRecord) -> None:
         with self.lock:
             self.records.append(record)
 
-    def fetch(self) -> List[logging.LogRecord]:
+    def fetch(self) -> list[logging.LogRecord]:
         with self.lock:
             records = self.records[:]
             self.records.clear()

--- a/diode_measurement/view/mainwindow.py
+++ b/diode_measurement/view/mainwindow.py
@@ -1,6 +1,6 @@
 import logging
 import webbrowser
-from typing import Dict, List, Optional
+from typing import Optional
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -122,7 +122,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.generalWidget = GeneralWidget()
         self.generalWidget.changeVoltageButton.clicked.connect(self.changeVoltageAction.trigger)
 
-        self.roleWidgets: Dict[str, RoleWidget] = {}
+        self.roleWidgets: dict[str, RoleWidget] = {}
 
         self.controlTabWidget = QtWidgets.QTabWidget()
         self.controlTabWidget.addTab(self.generalWidget, self.generalWidget.windowTitle())
@@ -378,7 +378,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def findRole(self, name: str) -> Optional[RoleWidget]:
         return self.roleWidgets.get(name)
 
-    def roles(self) -> List[RoleWidget]:
+    def roles(self) -> list[RoleWidget]:
         return list(self.roleWidgets.values())
 
     def clear(self) -> None:

--- a/diode_measurement/view/panels.py
+++ b/diode_measurement/view/panels.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from PyQt5 import QtWidgets
 
@@ -20,7 +20,7 @@ __all__ = [
     "BrandBoxPanel",
 ]
 
-ConfigType = Dict[str, Any]
+ConfigType = dict[str, Any]
 
 
 class WidgetParameter:
@@ -80,7 +80,7 @@ class InstrumentPanel(QtWidgets.QWidget):
 
     def __init__(self, model: str, parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
-        self._parameters: Dict[str, Any] = {}
+        self._parameters: dict[str, Any] = {}
         self.setModel(model)
 
     def model(self) -> str:

--- a/diode_measurement/view/plots.py
+++ b/diode_measurement/view/plots.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Any, Dict
+from typing import Any
 
 from PyQt5 import QtChart, QtCore, QtWidgets
 
@@ -136,7 +136,7 @@ class PlotWidget(QtChart.QChartView):
         layout.addWidget(self.resetButton)
         layout.addWidget(self.saveAsButton)
 
-        self.series: Dict[str, Any] = {}
+        self.series: dict[str, Any] = {}
 
     def mouseMoveEvent(self, event) -> None:
         self.toolbar.setVisible(self.underMouse())

--- a/diode_measurement/view/preferences.py
+++ b/diode_measurement/view/preferences.py
@@ -1,14 +1,14 @@
-from typing import List, Optional
+from typing import Optional
 
 from PyQt5 import QtCore, QtWidgets
 
-TIMESTAMP_FORMATS: List = [
+TIMESTAMP_FORMATS: list[str] = [
     ".3f",
     ".6f",
     ".9f",
 ]
 
-VALUE_FORMATS: List = [
+VALUE_FORMATS: list[str] = [
     "+.3E",
     "+.6E",
     "+.9E",

--- a/diode_measurement/view/role.py
+++ b/diode_measurement/view/role.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from PyQt5 import QtWidgets
 
@@ -15,7 +15,7 @@ class RoleWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self.setName(name)
 
-        self._resources: Dict[str, Any] = {}  # TODO
+        self._resources: dict[str, Any] = {}  # TODO
 
         self.resourceWidget = ResourceWidget(self)
         self.resourceWidget.modelChanged.connect(self.modelChanged)
@@ -63,10 +63,10 @@ class RoleWidget(QtWidgets.QWidget):
     def setTimeout(self, timeout: float) -> None:
         self.resourceWidget.setTimeout(timeout)
 
-    def resources(self) -> Dict[str, Any]:
+    def resources(self) -> dict[str, Any]:
         return self._resources.copy()
 
-    def setResources(self, resources: Dict[str, Any]) -> None:
+    def setResources(self, resources: dict[str, Any]) -> None:
         self._resources.update(resources)
 
     def syncCurrentResource(self) -> None:
@@ -80,19 +80,19 @@ class RoleWidget(QtWidgets.QWidget):
             }
             self._resources.setdefault(model, {}).update(resource)
 
-    def currentConfig(self) -> Dict[str, Any]:
+    def currentConfig(self) -> dict[str, Any]:
         widget = self.stackedWidget.currentWidget()
         if isinstance(widget, InstrumentPanel):
             return widget.config()
         return {}
 
-    def configs(self) -> Dict[str, Any]:
+    def configs(self) -> dict[str, Any]:
         configs = {}
         for widget in self.instrumentPanels():
             configs[widget.model()] = widget.config()
         return configs
 
-    def setConfigs(self, configs: Dict[str, Dict[str, Any]]) -> None:
+    def setConfigs(self, configs: dict[str, dict[str, Any]]) -> None:
         for widget in self.instrumentPanels():
             widget.setConfig(configs.get(widget.model(), {}))
 
@@ -106,7 +106,7 @@ class RoleWidget(QtWidgets.QWidget):
         self.resourceWidget.addModel(widget.model())
         self.stackedWidget.addWidget(widget)
 
-    def instrumentPanels(self) -> List[InstrumentPanel]:
+    def instrumentPanels(self) -> list[InstrumentPanel]:
         """Return list of registered instrument panels."""
         widgets = []
         for index in range(self.stackedWidget.count()):


### PR DESCRIPTION
Since the project requires **Python >= 3.9**, we can modernize type hints by replacing `typing.Dict`, `typing.List`, and `typing.Tuple` with the built-in generic types `dict`, `list`, and `tuple`.

This will simplify annotations and remove unnecessary imports from `typing`.

