### PR TITLE
Fix missing elm2 series population in IT plot

### DIFF
--- a/diode_measurement/controller.py
+++ b/diode_measurement/controller.py
@@ -1160,6 +1160,10 @@ class IVPlotsController(QtCore.QObject):
                 elmPoints.append(QtCore.QPointF(timestamp * 1e3, i_elm))
                 widget.iLimits.append(i_elm)
                 widget.tLimits.append(timestamp)
+            if math.isfinite(timestamp) and math.isfinite(i_elm2):
+                elm2Points.append(QtCore.QPointF(timestamp * 1e3, i_elm2))
+                widget.iLimits.append(i_elm2)
+                widget.tLimits.append(timestamp)
         widget.series.get("smu").replace(smuPoints)
         widget.series.get("smu2").replace(smu2Points)
         widget.series.get("elm").replace(elmPoints)


### PR DESCRIPTION
`i_elm2` readings were parsed but never appended to `elm2Points`, causing the elm2 plot series to remain empty. This change adds the missing append + limits updates so elm2 series renders correctly.
