### PR TITLE
bugfix: calling LCR finalize only if implemented

### DIFF
--- a/diode_measurement/core/measurement.py
+++ b/diode_measurement/core/measurement.py
@@ -522,7 +522,8 @@ class RangeMeasurement(Measurement):
     def finalize_lcr(self) -> None:
         lcr = self.instruments.get("lcr")
         if lcr is not None:
-            lcr.finalize()
+            if hasattr(lcr, "finalize"):
+                lcr.finalize()
 
     def finalize_switch(self) -> None:
         switch = self.instruments.get("switch")


### PR DESCRIPTION
This PR makes LCR finalize conditional to prevent exceptions at end of measurement.

`finalize` is only implemented for Keithely 5215 CVU