### PR TITLE
bugfix: RPC start command failed to start a measurement

### DIFF
--- a/diode_measurement/controller.py
+++ b/diode_measurement/controller.py
@@ -970,6 +970,12 @@ class Controller(QtCore.QObject):
             else:
                 raise KeyError(f"Invalid configuration key: {key}")
 
+    def request_start(self) -> None:
+        self.main_window.start_action.trigger()
+
+    def request_stop(self) -> None:
+        self.aborted.emit()
+
     def create_measurement(self) -> Measurement:
         measurement_type = self.state.measurement_type
         measurement_cls = MEASUREMENTS.get(measurement_type)

--- a/diode_measurement/plugins/rpcserver.py
+++ b/diode_measurement/plugins/rpcserver.py
@@ -44,13 +44,13 @@ class StartEvent:
 
     def __call__(self, controller: Controller) -> None:
         controller.configure(self.parameters)
-        controller.started.emit()
+        controller.request_start()
 
 
 @dataclass
 class StopEvent:
     def __call__(self, controller: Controller) -> None:
-        controller.aborted.emit()
+        controller.request_stop()
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes an issue in the RPC server’s start method that prevented new measurement jobs from starting and caused the GUI to freeze.

The bug was introduced in version 0.23.0 with the addition of the background job pipeline, which was implemented to support the CVU open correction action.