### PR TITLE
Fix RPC state not updating

### DIFF
--- a/diode_measurement/core/measurement.py
+++ b/diode_measurement/core/measurement.py
@@ -77,7 +77,7 @@ class Measurement:
             raise RuntimeError(f"Instrument Error: {error.code}: {error.message}")
 
     def set_fsm_state(self, state: FSMState) -> None:
-        self.update_event({"rpc_state": state})
+        self.update_event({"fsm_state": state})
 
     def initialize(self) -> None: ...
 


### PR DESCRIPTION
Fixes an issue where the RCP state was not updating due to a typo in the FSM dictionary key (state was stuck in `idle` regardless of actual operation).