### PR TITLE
Update instrument options usign RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Request an application state snapshot.
 {"jsonrpc": "2.0", "method": "state", "id": 0}
 ```
 
-This will return application state parameters.
+This returns application state parameters.
 
 ```json
 {
@@ -286,6 +286,96 @@ This will return application state parameters.
   "id": 0
 }
 ```
+
+#### Get Instrument Options
+
+Get current instrument options using method `instrument.get`.
+
+Required parameter is:
+
+- `instrument` (one of `smu`, `smu2`, `elm`, `elm2`, `lcr`, `dmm`, `tcu`, `switch`)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "instrument.get",
+  "params": {
+    "instrument": "smu"
+  },
+  "id": 1
+}
+```
+
+This returns the current model's instrument options.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "instrument": "smu",
+    "model": "K2410",
+    "options": {
+      "filter.enable": false,
+      "filter.count": 10,
+      "filter.mode": "REP",
+      "nplc": 1.0,
+      "route.terminals": "REAR",
+      "system.breakdown.protection": false,
+    }
+  },
+  "id": 1
+}
+```
+
+**Note:** option keys might change in future releases.
+
+#### Update Instrument Options
+
+Update current instrument options using method `instrument.update`.
+
+
+Required parameters are:
+
+- `instrument` (one of `smu`, `smu2`, `elm`, `elm2`, `lcr`, `dmm`, `tcu`, `switch`)
+- `options` (specific to selected instrument model)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "instrument.update",
+  "params": {
+    "instrument": "smu",
+    "options" : {
+      "filter.enable": true,
+      "filter.count": 25,
+    }
+  },
+  "id": 2
+}
+```
+
+This returns the current model's updated instrument options.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "instrument": "smu",
+    "model": "K2410",
+    "options": {
+      "filter.enable": true,
+      "filter.count": 25,
+      "filter.mode": "REP",
+      "nplc": 1.0,
+      "route.terminals": "REAR",
+      "system.breakdown.protection": false,
+    }
+  },
+  "id": 2
+}
+```
+
+**Note:** option keys might change in future releases.
 
 ### States
 

--- a/src/diode_measurement/controller.py
+++ b/src/diode_measurement/controller.py
@@ -313,6 +313,35 @@ class Controller(QtCore.QObject):
                 temperature=self.cache.get("dmm_temperature"),
             )
 
+    def get_role_model(self, role: str) -> str:
+        for role_ in self.main_window.roles():
+            if role_.name() == role:
+                return role_.model()
+        raise KeyError("No such role: {role!r}")
+
+    def get_role_config(self, role: str) -> dict[str, Any]:
+        for role_ in self.main_window.roles():
+            if role_.name() == role:
+                return role_.current_config()
+        raise KeyError("No such role: {role!r}")
+
+    def update_role_config(self, role: str, options: Mapping[str, Any]) -> dict[str, Any]:
+        for role_ in self.main_window.roles():
+            if role_.name() == role:
+                config = role_.current_config()
+                for key in options:
+                    if key not in config:
+                        logger.warning("Ignoring invalid config key %r for role %r", key, role)
+                for key in config:
+                    if key in options:
+                        config[key] = options[key]
+                # Update models configs
+                configs = role_.configs()
+                configs[role_.model()] = config
+                role_.set_configs(configs)
+                return role_.current_config()
+        raise KeyError("No such role: {role!r}")
+
     def prepare_state(self) -> dict[str, Any]:
         state: dict[str, Any] = {}
 

--- a/src/diode_measurement/plugins/rpcserver.py
+++ b/src/diode_measurement/plugins/rpcserver.py
@@ -74,6 +74,35 @@ class StateEvent:
 
 
 @dataclass
+class InstrumentGetEvent:
+    instrument: str
+
+    def __call__(self, controller: Controller) -> dict[str, Any]:
+        model = controller.get_role_model(self.instrument)
+        options = controller.get_role_config(self.instrument)
+        return {
+            "instrument": self.instrument,
+            "model": model,
+            "options": options,
+         }
+
+
+@dataclass
+class InstrumentUpdateEvent:
+    instrument: str
+    options: dict[str, Any]
+
+    def __call__(self, controller: Controller) -> dict[str, Any]:
+        model = controller.get_role_model(self.instrument)
+        options = controller.update_role_config(self.instrument, self.options)
+        return {
+            "instrument": self.instrument,
+            "model": model,
+            "options": options,
+         }
+
+
+@dataclass
 class Envelope:
     event: Any
     future: Future
@@ -127,6 +156,8 @@ class RPCHandler:
         self.dispatcher["stop"] = self.on_stop
         self.dispatcher["change_voltage"] = self.on_change_voltage
         self.dispatcher["state"] = self.on_state
+        self.dispatcher["instrument.get"] = self.on_instrument_get
+        self.dispatcher["instrument.update"] = self.on_instrument_update
         self.manager = jsonrpc.JSONRPCResponseManager()
 
     def handle(self, request) -> dict[str, Any]:
@@ -188,6 +219,14 @@ class RPCHandler:
     def on_state(self) -> dict[str, Any]:
         result = self.event_handler.notify(StateEvent()).result(self.timeout)
         return json_dict(result)
+
+    def on_instrument_get(self, instrument: str) -> dict[str, Any]:
+        event = InstrumentGetEvent(instrument=instrument)
+        return self.event_handler.notify(event).result(self.timeout)
+
+    def on_instrument_update(self, instrument: str, options: dict[str, Any]) -> dict[str, Any]:
+        event = InstrumentUpdateEvent(instrument=instrument, options=options)
+        return self.event_handler.notify(event).result(self.timeout)
 
 
 class AsyncioTCPServer:


### PR DESCRIPTION
This PR adds new RPC methods `instrument.get` and `instrument.update` to change an instruments current models option visible in the GUI.

