### PR TITLE
Missing INIT when reading IV from 2470

### DIFF
--- a/src/diode_measurement/drivers/k2470.py
+++ b/src/diode_measurement/drivers/k2470.py
@@ -77,8 +77,13 @@ class K2470(BaseDriver):
         return v
 
     def measure_iv(self) -> tuple[float, float]:
-        self._write(':TRAC:TRIG "defbuffer1"')
-        result = self._query(':TRAC:DATA? 1, 1, "defbuffer1", SOUR, READ')
+        """Measure I and V at once using a trace buffer."""
+        resource = self.resource
+        resource.write(":TRAC:CLE \"defbuffer1\"")
+        resource.write(":TRAC:TRIG \"defbuffer1\"")
+        resource.write(":INIT")
+        resource.query("*OPC?")  # NOTE: depends on timeout
+        result = resource.query(":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ")
         try:
             source, reading = result.split(",", 1)
             return float(reading), float(source)

--- a/tests/test_driver_k2470.py
+++ b/tests/test_driver_k2470.py
@@ -53,7 +53,9 @@ def test_driver_k2470(res):
     res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
     assert d.measure_i() == 0.00421
     assert res.buffer == [
+        ":TRAC:CLE \"defbuffer1\"",
         ":TRAC:TRIG \"defbuffer1\"",
+        ":INIT",
         "*OPC?",
         ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
     ]
@@ -61,7 +63,9 @@ def test_driver_k2470(res):
     res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
     assert d.measure_v() == 42.1
     assert res.buffer == [
+        ":TRAC:CLE \"defbuffer1\"",
         ":TRAC:TRIG \"defbuffer1\"",
+        ":INIT",
         "*OPC?",
         ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
     ]
@@ -69,7 +73,9 @@ def test_driver_k2470(res):
     res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
     assert d.measure_iv() == (0.00421, 42.1)
     assert res.buffer == [
+        ":TRAC:CLE \"defbuffer1\"",
         ":TRAC:TRIG \"defbuffer1\"",
+        ":INIT",
         "*OPC?",
         ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
     ]


### PR DESCRIPTION
This PR fixes a missing `INIT` command when reading IV data from a Keithley 2470, which previously caused readings to freeze.

Additionally, the trace buffer is now cleared before measurements, making potential issues more visible (e.g., returning zeros instead of stale data).

See also #147