### PR TITLE
bugfix: replaces INIT by READ? for K2470

### DIFF
--- a/src/diode_measurement/drivers/k2470.py
+++ b/src/diode_measurement/drivers/k2470.py
@@ -77,18 +77,13 @@ class K2470(BaseDriver):
         return v
 
     def measure_iv(self) -> tuple[float, float]:
-        """Measure I and V at once using a trace buffer."""
-        resource = self.resource
-        resource.write(":TRAC:CLE \"defbuffer1\"")
-        resource.write(":TRAC:TRIG \"defbuffer1\"")
-        resource.write(":INIT")
-        resource.query("*OPC?")  # NOTE: depends on timeout
-        result = resource.query(":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ")
+        """Measure I and V at once using READ?."""
+        result = self.resource.query(":READ? \"defbuffer1\", SOUR, READ")
         try:
             source, reading = result.split(",", 1)
             return float(reading), float(source)
         except Exception as exc:
-            raise ValueError(f"Unexpected instrument response: {result!r}") from exc
+            raise ValueError(f"Unexpected instrument response for READ?: {result!r}") from exc
 
     def set_route_terminals(self, terminal: str) -> None:
         self._write(f":ROUT:TERM {terminal}")

--- a/tests/test_driver_k2470.py
+++ b/tests/test_driver_k2470.py
@@ -50,35 +50,17 @@ def test_driver_k2470(res):
     assert d.compliance_tripped() is True
     assert res.buffer == [":SOUR:VOLT:ILIM:LEV:TRIP?"]
 
-    res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
+    res.buffer = ["+4.210000E+01,+4.210000E-03"]
     assert d.measure_i() == 0.00421
-    assert res.buffer == [
-        ":TRAC:CLE \"defbuffer1\"",
-        ":TRAC:TRIG \"defbuffer1\"",
-        ":INIT",
-        "*OPC?",
-        ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
-    ]
+    assert res.buffer == [":READ? \"defbuffer1\", SOUR, READ",]
 
-    res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
+    res.buffer = ["+4.210000E+01,+4.210000E-03"]
     assert d.measure_v() == 42.1
-    assert res.buffer == [
-        ":TRAC:CLE \"defbuffer1\"",
-        ":TRAC:TRIG \"defbuffer1\"",
-        ":INIT",
-        "*OPC?",
-        ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
-    ]
+    assert res.buffer == [":READ? \"defbuffer1\", SOUR, READ",]
 
-    res.buffer = ["1", "+4.210000E+01,+4.210000E-03"]
+    res.buffer = ["+4.210000E+01,+4.210000E-03"]
     assert d.measure_iv() == (0.00421, 42.1)
-    assert res.buffer == [
-        ":TRAC:CLE \"defbuffer1\"",
-        ":TRAC:TRIG \"defbuffer1\"",
-        ":INIT",
-        "*OPC?",
-        ":TRAC:DATA? 1, 1, \"defbuffer1\", SOUR, READ",
-    ]
+    assert res.buffer == [":READ? \"defbuffer1\", SOUR, READ",]
 
     res.buffer = ["1"]
     assert d.set_route_terminals("REAR") is None


### PR DESCRIPTION
This PR replaces `:INIT` sequence for taking a measurement with the Keithley 24170 by `:READ?` to overcome the empty trigger model issue.
 
See #158