### PR TITLE
Configurable discharge threshold and timeout

### DIFF
--- a/src/diode_measurement/controller.py
+++ b/src/diode_measurement/controller.py
@@ -1062,18 +1062,17 @@ class Controller(QtCore.QObject):
             # Create and run measurement
             measurement = self.create_measurement(self.state)
 
-            options: dict[str, Any] = {}
-
             settings = QtCore.QSettings()
-            timestamp_format = settings.value("writer/timestampFormat", ".6f", str)
-            valueFormat = settings.value("writer/valueFormat", "+.3E", str)
+            timestamp_format = get_str(settings.value("writer/timestampFormat"), ".6f")
+            value_format = get_str(settings.value("writer/valueFormat"), "+.3E")
 
-            options.update(
-                {
-                    "timestamp_format": timestamp_format,
-                    "value_format": valueFormat,
-                }
-            )
+            # discharge guard
+            discharge_timeout = get_float(settings.value("misc/discharge_timeout"), 60.0)
+            discharge_threshold = get_float(settings.value("misc/discharge_threshold"), 0.5)
+            self.state.update({
+                "discharge_timeout": discharge_timeout,
+                "discharge_threshold": discharge_threshold,
+            })
 
             self.main_window.clear()
             self.iv_plots_controller.clear()
@@ -1082,7 +1081,10 @@ class Controller(QtCore.QObject):
             self.cv_plots_controller.update_timer.start(500)
 
             job = MeasurementJob(
-                measurement, options, has_finished=self.measurement_finished.emit
+                measurement,
+                timestamp_format=timestamp_format,
+                value_format=value_format,
+                has_finished=self.measurement_finished.emit,
             )
             self.submit_background_job(job)
 

--- a/src/diode_measurement/core/measurement.py
+++ b/src/diode_measurement/core/measurement.py
@@ -617,27 +617,29 @@ class RangeMeasurement(Measurement):
             logger.info("Switch: opened ALL channels")
 
     def assure_discharge(self) -> None:
-        # wait until capacitors discared before output disable
+        """Wait until capacitors discared before output disable."""
+
+        discharge_timeout: float = self.state.discharge_timeout
+        discharge_threshold: float = abs(self.state.discharge_threshold)
+
         def read_source_voltage():
             if isinstance(self.source_instrument, VoltageMeasurable):
                 return self.source_instrument.measure_v()
             logger.warning("Source instrument does not provide voltage readings.")
             return 0.0
 
-        threshold: float = 0.5  # Volt
-
         self.update_message("Waiting for voltage settled...")
         self.update_progress(0, 0, 0)
 
-        t = time.monotonic()
+        start = time.monotonic()
 
-        while abs(read_source_voltage()) > threshold:
+        while abs(read_source_voltage()) > discharge_threshold:
             time.sleep(1.0)
 
-            dt = time.monotonic() - t
-            if dt > 60.0:
-                raise RuntimeError(
-                    f"Timeout while waiting for voltage to settle < {threshold} V, source output still enabled."
+            delta = time.monotonic() - start
+            if delta > discharge_timeout:
+                raise TimeoutError(
+                    f"Timeout while waiting for voltage to settle < {discharge_threshold} V, source output still enabled."
                 )
 
         self.update_message("")

--- a/src/diode_measurement/gui/preferences.py
+++ b/src/diode_measurement/gui/preferences.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from PySide6 import QtCore, QtWidgets
 
-from ..utils import get_str
+from ..utils import get_str, get_float
 
 TIMESTAMP_FORMATS: list[str] = [
     ".3f",
@@ -25,34 +25,21 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.setWindowTitle("Preferences")
         self.setMinimumSize(320, 240)
 
-        # Output Tab
-
-        self.output_widget = QtWidgets.QWidget(self)
-
-        self.timestamp_format_combo_box = QtWidgets.QComboBox(self.output_widget)
-
-        for timestamp_format in TIMESTAMP_FORMATS:
-            self.timestamp_format_combo_box.addItem(
-                format(1.0, timestamp_format), timestamp_format
-            )
-
-        self.value_format_combo_box = QtWidgets.QComboBox(self.output_widget)
-
-        for value_format in VALUE_FORMATS:
-            self.value_format_combo_box.addItem(format(1.0, value_format), value_format)
-
-        output_widget_layout = QtWidgets.QFormLayout(self.output_widget)
-        output_widget_layout.addRow("Timestamp Format", self.timestamp_format_combo_box)
-        output_widget_layout.addRow("Value Format", self.value_format_combo_box)
+        self.output_widget = OutputWidget(self)
+        self.misc_widget = MiscWidget(self)
 
         self.tab_widget = QtWidgets.QTabWidget(self)
         self.tab_widget.addTab(self.output_widget, "Output")
+        self.tab_widget.addTab(self.misc_widget, "Misc")
 
         self.dialog_button_box = QtWidgets.QDialogButtonBox(self)
-        self.dialog_button_box.addButton(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        self.dialog_button_box.addButton(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
         self.dialog_button_box.addButton(
             QtWidgets.QDialogButtonBox.StandardButton.Cancel
         )
+
         self.dialog_button_box.accepted.connect(self.accept)
         self.dialog_button_box.rejected.connect(self.reject)
 
@@ -60,38 +47,127 @@ class PreferencesDialog(QtWidgets.QDialog):
         layout.addWidget(self.tab_widget)
         layout.addWidget(self.dialog_button_box)
 
+    def read_settings(self) -> None:
+        self.output_widget.read_settings()
+        self.misc_widget.read_settings()
+
+    def write_settings(self) -> None:
+        self.output_widget.write_settings()
+        self.misc_widget.write_settings()
+
+
+class OutputWidget(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self.timestamp_format_combo_box = QtWidgets.QComboBox(self)
+
+        for timestamp_format in TIMESTAMP_FORMATS:
+            self.timestamp_format_combo_box.addItem(
+                format(1.0, timestamp_format),
+                timestamp_format,
+            )
+
+        self.value_format_combo_box = QtWidgets.QComboBox(self)
+
+        for value_format in VALUE_FORMATS:
+            self.value_format_combo_box.addItem(
+                format(1.0, value_format),
+                value_format,
+            )
+
+        layout = QtWidgets.QFormLayout(self)
+        layout.addRow("Timestamp Format", self.timestamp_format_combo_box)
+        layout.addRow("Value Format", self.value_format_combo_box)
+
     def timestamp_format(self) -> str:
         value = self.timestamp_format_combo_box.currentData()
         return value if isinstance(value, str) else TIMESTAMP_FORMATS[1]
 
     def set_timestamp_format(self, timestamp_format: str) -> None:
-        """Select the timestamp format, falling back to the default if unknown."""
         index = self.timestamp_format_combo_box.findData(timestamp_format)
         if index < 0:
-            index = 1  # default: TIMESTAMP_FORMATS[1]
+            index = 1
         self.timestamp_format_combo_box.setCurrentIndex(index)
 
-    def valueFormat(self) -> str:
+    def value_format(self) -> str:
         value = self.value_format_combo_box.currentData()
         return value if isinstance(value, str) else VALUE_FORMATS[0]
 
     def set_value_format(self, value_format: str) -> None:
-        """Select the value format, falling back to the default if unknown."""
         index = self.value_format_combo_box.findData(value_format)
         if index < 0:
-            index = 0  # default: VALUE_FORMATS[0]
+            index = 0
         self.value_format_combo_box.setCurrentIndex(index)
 
     def read_settings(self) -> None:
         settings = QtCore.QSettings()
+
         timestamp_format = get_str(
-            settings.value("writer/timestampFormat"), TIMESTAMP_FORMATS[1]
+            settings.value("writer/timestampFormat"),
+            TIMESTAMP_FORMATS[1],
         )
         self.set_timestamp_format(timestamp_format)
-        value_format = get_str(settings.value("writer/valueFormat"), VALUE_FORMATS[0])
+
+        value_format = get_str(
+            settings.value("writer/valueFormat"),
+            VALUE_FORMATS[0],
+        )
         self.set_value_format(value_format)
 
     def write_settings(self) -> None:
         settings = QtCore.QSettings()
+
         settings.setValue("writer/timestampFormat", self.timestamp_format())
-        settings.setValue("writer/valueFormat", self.valueFormat())
+        settings.setValue("writer/valueFormat", self.value_format())
+
+
+class MiscWidget(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self.discharge_timeout_spin_box = QtWidgets.QDoubleSpinBox(self)
+        self.discharge_timeout_spin_box.setRange(0.0, 360.0)
+        self.discharge_timeout_spin_box.setSuffix(" s")
+        self.discharge_timeout_spin_box.setDecimals(1)
+        self.discharge_timeout_spin_box.setSingleStep(1.0)
+        self.discharge_timeout_spin_box.setToolTip(
+            "Sets the timeout for voltage discharge. "
+            "The discharge waits until the source voltage is below the discharge threshold."
+        )
+
+        self.discharge_threshold_spin_box = QtWidgets.QDoubleSpinBox(self)
+        self.discharge_threshold_spin_box.setRange(0.0, 1_000_000.0)
+        self.discharge_threshold_spin_box.setSuffix(" V")
+        self.discharge_threshold_spin_box.setDecimals(3)
+        self.discharge_threshold_spin_box.setSingleStep(0.1)
+        self.discharge_threshold_spin_box.setToolTip(
+            "Voltage threshold below which the source is considered discharged."
+        )
+
+        layout = QtWidgets.QFormLayout(self)
+        layout.addRow("Discharge timeout", self.discharge_timeout_spin_box)
+        layout.addRow("Discharge threshold", self.discharge_threshold_spin_box)
+
+        self.read_settings()
+
+    def read_settings(self) -> None:
+        settings = QtCore.QSettings()
+
+        discharge_timeout = get_float(settings.value("misc/discharge_timeout"), 60.0)
+        discharge_threshold = get_float(settings.value("misc/discharge_threshold"), 0.5)
+
+        self.discharge_timeout_spin_box.setValue(discharge_timeout)
+        self.discharge_threshold_spin_box.setValue(discharge_threshold)
+
+    def write_settings(self) -> None:
+        settings = QtCore.QSettings()
+
+        settings.setValue(
+            "misc/discharge_timeout",
+            self.discharge_timeout_spin_box.value(),
+        )
+        settings.setValue(
+            "misc/discharge_threshold",
+            self.discharge_threshold_spin_box.value(),
+        )

--- a/src/diode_measurement/jobs.py
+++ b/src/diode_measurement/jobs.py
@@ -3,8 +3,8 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from collections.abc import Callable, Mapping
-from typing import Any, Optional, Protocol
+from collections.abc import Callable
+from typing import Optional, Protocol
 
 from .core.resource import parse_resource, Resource
 
@@ -23,18 +23,15 @@ class Job(Protocol):
 @dataclass
 class MeasurementJob:
     measurement: Measurement
-    options: Mapping[str, Any]
+    timestamp_format: str
+    value_format: str
     has_finished: Callable[[], None]
 
     def create_writer(self, fp) -> Writer:
         writer: Writer = Writer(fp)
         # Configure writer
-        timestamp_format = self.options.get("timestamp_format")
-        if timestamp_format is not None:
-            writer.timestamp_format = timestamp_format
-        value_format = self.options.get("value_format")
-        if value_format is not None:
-            writer.value_format = value_format
+        writer.timestamp_format = self.timestamp_format
+        writer.value_format = self.value_format
         return writer
 
     def __call__(self) -> None:

--- a/src/diode_measurement/state.py
+++ b/src/diode_measurement/state.py
@@ -168,6 +168,16 @@ class State:
             return self._state.get("bias_source_role")
 
     @property
+    def discharge_timeout(self) -> float:
+        with self._lock:
+            return self._state.get("discharge_timeout", 60.0)
+
+    @property
+    def discharge_threshold(self) -> float:
+        with self._lock:
+            return self._state.get("discharge_threshold", 0.5)
+
+    @property
     def is_change_voltage_continuous(self) -> bool:
         with self._lock:
             return self._change_voltage_parameters is not None


### PR DESCRIPTION
This PR adds configurable voltage discharge threshold and timeout settings to the Preferences dialog.

The default values remain 60 s for the timeout and 0.5 V for the discharge threshold.

Can be edited in Edit -> Preferences -> Misc