### PR TITLE
Set sample name using JSON-RPC

### DIFF
--- a/scripts/rpc_client.py
+++ b/scripts/rpc_client.py
@@ -2,7 +2,7 @@ import json
 import socket
 from typing import Any
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 class DiodeMeasurementError(Exception):
@@ -82,6 +82,7 @@ class DiodeMeasurementClient:
         auto_reconnect: bool | None = None,
         measurement_type: str | None = None,
         measurement_instruments: list[str] | None = None,
+        sample: str | None = None,
         begin_voltage: float | None = None,
         end_voltage: float | None = None,
         step_voltage: float | None = None,
@@ -99,6 +100,8 @@ class DiodeMeasurementClient:
             params["measurement_type"] = measurement_type
         if measurement_instruments is not None:
             params["measurement_instruments"] = measurement_instruments
+        if sample is not None:
+            params["sample"] = sample
         if begin_voltage is not None:
             params["begin_voltage"] = begin_voltage
         if end_voltage is not None:

--- a/scripts/rpc_iv_example.py
+++ b/scripts/rpc_iv_example.py
@@ -21,6 +21,7 @@ client.instrument_update("smu", options)
 # Start a measurement
 print("Starting measurement...")
 client.start(
+    sample="DIODE_002",
     measurement_type="iv",
     measurement_instruments=["smu"],
     continuous=True,

--- a/src/diode_measurement/controller.py
+++ b/src/diode_measurement/controller.py
@@ -1011,6 +1011,8 @@ class Controller(QtCore.QObject):
                 general_widget.set_current_measurement(value)
             elif key == "measurement_roles":
                 general_widget.set_measurement_roles(value)
+            elif key == "sample":
+                general_widget.set_sample_name(value)
             elif key == "end_voltage":
                 general_widget.set_end_voltage(value)
             elif key == "begin_voltage":

--- a/src/diode_measurement/plugins/rpcserver.py
+++ b/src/diode_measurement/plugins/rpcserver.py
@@ -170,6 +170,7 @@ class RPCHandler:
         auto_reconnect: Optional[bool] = None,
         measurement_type: Optional[str] = None,
         measurement_instruments: Optional[list[str]] = None,
+        sample: Optional[str] = None,
         begin_voltage: Optional[float] = None,
         end_voltage: Optional[float] = None,
         step_voltage: Optional[float] = None,
@@ -186,6 +187,8 @@ class RPCHandler:
             parameters["measurement_type"] = measurement_type
         if measurement_instruments is not None:
             parameters["measurement_roles"] = measurement_instruments
+        if sample is not None:
+            parameters["sample"] = sample
         if begin_voltage is not None:
             parameters["begin_voltage"] = begin_voltage
         if end_voltage is not None:


### PR DESCRIPTION
This PR adds a `sample` parameter to the RPC `start` method enabling to set the name of a sample when starting a measurement.

```json
{
  "jsonrpc": "2.0",
  "method": "start",
  "params": {
    "sample": "diode_002"
  }
}
```