### PR TITLE
Configure baud rate for serial resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Instrument resource name inputs accept the following formats:
 | `<ip>:<port>`   | `0.0.0.0:1080`     | `TCPIP::0.0.0.0::1080::SOCKET`   |
 | `<host>:<port>` | `localhost:1080`   | `TCPIP::localhost::1080::SOCKET` |
 | `<visa>`        | `GPIB1::16::INSTR` | `GPIB1::16::INSTR`               |
+| `<serial_port>` | `COM1`             | `ASRL1::INSTR`                   |
 
 This allows both simplified and explicit VISA resource definitions depending on your setup.
 

--- a/src/diode_measurement/controller.py
+++ b/src/diode_measurement/controller.py
@@ -381,6 +381,7 @@ class Controller(QtCore.QObject):
                     "model": role.resource_widget.model(),
                     "termination": role.resource_widget.termination(),
                     "timeout": role.resource_widget.timeout(),
+                    "baud_rate": role.resource_widget.baud_rate(),
                     "reset_instrument": role.resource_widget.is_reset_instrument(),
                 }
             )
@@ -525,6 +526,7 @@ class Controller(QtCore.QObject):
             role.set_resource_name(get_str(settings.value("resource"), ""))
             role.set_termination(get_str(settings.value("termination"), ""))
             role.set_timeout(get_float(settings.value("timeout"), 4.0))
+            role.set_baud_rate(get_int(settings.value("baud_rate"), 9_600))
             role.set_reset_instrument(get_bool(settings.value("reset_instrument"), False))
             role.set_resources(get_dict(settings.value("resources"), {}))
             role.set_configs(get_dict(settings.value("configs"), {}))
@@ -621,6 +623,7 @@ class Controller(QtCore.QObject):
             settings.setValue("resource", role.resource_name())
             settings.setValue("termination", role.termination())
             settings.setValue("timeout", role.timeout())
+            settings.setValue("baud_rate", role.baud_rate())
             settings.setValue("reset_instrument", role.is_reset_instrument())
             settings.setValue("resources", role.resources())
             settings.setValue("configs", role.configs())
@@ -1138,6 +1141,7 @@ class Controller(QtCore.QObject):
                 visa_library=visa_library,
                 termination=role.termination(),
                 timeout=role.timeout(),
+                baud_rate=role.baud_rate(),
             )
 
             self.submit_background_job(

--- a/src/diode_measurement/core/resource.py
+++ b/src/diode_measurement/core/resource.py
@@ -23,19 +23,24 @@ def parse_resource(resource_name: str) -> tuple[str, str]:
     """Create valid VISA resource name for short descriptors."""
     resource_name = resource_name.strip()
 
-    m = re.match(r"^(\d+)$", resource_name)
-    if m:
+    if m := re.match(r"^(\d+)$", resource_name):
         resource_name = f"GPIB0::{m.group(1)}::INSTR"
 
-    m = re.match(r"^(\d+\.\d+\.\d+\.\d+)\:(\d+)$", resource_name)
-    if m:
+    if m := re.match(r"^COM(\d+)$", resource_name):
+        resource_name = f"ASRL{m.group(1)}::INSTR"
+
+    if m := re.match(r"^ASRL(\d+)$", resource_name):
+        resource_name = f"ASRL{m.group(1)}::INSTR"
+
+    if m := re.match(r"^(\d+\.\d+\.\d+\.\d+)\:(\d+)$", resource_name):
         resource_name = f"TCPIP0::{m.group(1)}::{m.group(2)}::SOCKET"
 
-    m = re.match(r"^(\w+)\:(\d+)$", resource_name)
-    if m:
+    if m := re.match(r"^(\w+)\:(\d+)$", resource_name):
         resource_name = f"TCPIP0::{m.group(1)}::{m.group(2)}::SOCKET"
 
     visa_library = ""
+    if resource_name.startswith("ASRL"):
+        visa_library = "@py"
     if resource_name.startswith("TCPIP"):
         visa_library = "@py"
 
@@ -45,9 +50,10 @@ def parse_resource(resource_name: str) -> tuple[str, str]:
 @dataclass
 class ResourceConfig:
     resource_name: str
-    visa_library: str
+    visa_library: str = "@py"
     termination: str = "\n"
     timeout: float = 4.0
+    baud_rate: int = 9_600
 
 
 class ResourceError(Exception): ...
@@ -63,12 +69,17 @@ class Resource:
         try:
             resource_config = self._resource_config
             self._rm = pyvisa.ResourceManager(resource_config.visa_library)
+
             resource = self._rm.open_resource(
                 resource_name=resource_config.resource_name,
                 read_termination=resource_config.termination,
                 write_termination=resource_config.termination,
-                timeout=resource_config.timeout * 1e3,  # millisecs
+                timeout=resource_config.timeout * 1_000,  # millisecs
             )
+
+            if hasattr(resource, "baud_rate"):
+                resource.baud_rate = resource_config.baud_rate  # type: ignore
+
             if not isinstance(resource, MessageBasedResource):
                 resource.close()
                 raise TypeError(f"Expected MessageBasedResource, got {type(resource).__name__}")

--- a/src/diode_measurement/gui/resource.py
+++ b/src/diode_measurement/gui/resource.py
@@ -7,6 +7,20 @@ from ..drivers import driver_factory
 
 __all__ = ["ResourceWidget"]
 
+BAUD_RATES: list[int] = [
+    1200,
+    2400,
+    4800,
+    9600,
+    19200,
+    38400,
+    57600,
+    115200,
+    230400,
+    460800,
+    921600,
+]
+
 
 class ResourceWidget(QtWidgets.QGroupBox):
     model_changed = QtCore.Signal(str)
@@ -27,13 +41,21 @@ class ResourceWidget(QtWidgets.QGroupBox):
         self.resource_line_edit.setStatusTip(
             "Instrument resource GPIB number, IP and port or any valid VISA resource name."
         )
+        self.resource_line_edit.textChanged.connect(
+            self.on_update_baud_rate_visibility
+        )
+
+        self.baud_rate_label = QtWidgets.QLabel("Baud Rate", self)
+
+        self.baud_rate_combo_box = QtWidgets.QComboBox(self)
+        self.baud_rate_combo_box.setStatusTip("Baud rate for serial connections.")
+        for baud_rate in BAUD_RATES:
+            self.baud_rate_combo_box.addItem(str(baud_rate), baud_rate)
 
         self.termination_label = QtWidgets.QLabel("Termination", self)
 
         self.termination_combo_box = QtWidgets.QComboBox(self)
-        self.termination_combo_box.setStatusTip(
-            "Read and write termination characters."
-        )
+        self.termination_combo_box.setStatusTip("Read and write termination characters.")
         self.termination_combo_box.addItem("CR+LF", "\r\n")
         self.termination_combo_box.addItem("CR", "\r")
         self.termination_combo_box.addItem("LF", "\n")
@@ -51,31 +73,44 @@ class ResourceWidget(QtWidgets.QGroupBox):
         self.test_connection_button.setText("&Test")
         self.test_connection_button.setStatusTip("Test instrument connection.")
         self.test_connection_button.setMaximumWidth(48)
-        self.test_connection_button.clicked.connect(self.test_conntection)
+        self.test_connection_button.clicked.connect(self.on_test_conntection)
 
         self.reset_instrument_check_box = QtWidgets.QCheckBox(self)
         self.reset_instrument_check_box.setText("Reset Instrument")
         self.reset_instrument_check_box.setStatusTip("Reset instrument on start measurement")
 
         layout = QtWidgets.QGridLayout(self)
+
         layout.addWidget(self.model_label, 0, 0, 1, 3)
         layout.addWidget(self.model_combo_box, 1, 0, 1, 3)
+
         layout.addWidget(self.resource_label, 2, 0, 1, 3)
         layout.addWidget(self.resource_line_edit, 3, 0, 1, 3)
-        layout.addWidget(self.termination_label, 4, 0, 1, 1)
-        layout.addWidget(self.timeout_label, 4, 1, 1, 1)
-        layout.addWidget(self.termination_combo_box, 5, 0, 1, 1)
-        layout.addWidget(self.timeout_spin_box, 5, 1, 1, 1)
-        layout.addWidget(self.test_connection_button, 5, 2, 1, 1)
-        layout.addWidget(self.reset_instrument_check_box, 6, 0, 1, 3)
-        layout.setRowStretch(7, 1)
+
+        layout.addWidget(self.baud_rate_label, 4, 0, 1, 3)
+        layout.addWidget(self.baud_rate_combo_box, 5, 0, 1, 3)
+
+        layout.addWidget(self.termination_label, 6, 0, 1, 1)
+        layout.addWidget(self.timeout_label, 6, 1, 1, 1)
+
+        layout.addWidget(self.termination_combo_box, 7, 0, 1, 1)
+        layout.addWidget(self.timeout_spin_box, 7, 1, 1, 1)
+        layout.addWidget(self.test_connection_button, 7, 2, 1, 1)
+
+        layout.addWidget(self.reset_instrument_check_box, 8, 0, 1, 3)
+
+        layout.setRowStretch(9, 1)
+
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
         layout.setColumnStretch(2, 0)
 
+        self.on_update_baud_rate_visibility()
+
     def set_locked(self, state: bool) -> None:
         self.model_combo_box.setEnabled(not state)
         self.resource_line_edit.setEnabled(not state)
+        self.baud_rate_combo_box.setEnabled(not state)
         self.termination_combo_box.setEnabled(not state)
         self.timeout_spin_box.setEnabled(not state)
         self.test_connection_button.setEnabled(not state)
@@ -111,6 +146,13 @@ class ResourceWidget(QtWidgets.QGroupBox):
     def set_timeout(self, timeout: float) -> None:
         self.timeout_spin_box.setValue(timeout)
 
+    def baud_rate(self) -> int:
+        return self.baud_rate_combo_box.currentData()
+
+    def set_baud_rate(self, baud_rate: int) -> None:
+        index = self.baud_rate_combo_box.findData(baud_rate)
+        self.baud_rate_combo_box.setCurrentIndex(max(0, index))
+
     def is_reset_instrument(self) -> bool:
         return self.reset_instrument_check_box.isChecked()
 
@@ -137,7 +179,17 @@ class ResourceWidget(QtWidgets.QGroupBox):
             return instr.identify()
 
     @QtCore.Slot()
-    def test_conntection(self) -> None:
+    def on_update_baud_rate_visibility(self) -> None:
+        text = self.resource_line_edit.text().strip().upper()
+        is_serial = (
+            text.startswith("ASRL")
+            or text.startswith("COM")
+        )
+        self.baud_rate_label.setEnabled(is_serial)
+        self.baud_rate_combo_box.setEnabled(is_serial)
+
+    @QtCore.Slot()
+    def on_test_conntection(self) -> None:
         try:
             identity = self.read_identity()
         except Exception as exc:

--- a/src/diode_measurement/gui/role.py
+++ b/src/diode_measurement/gui/role.py
@@ -62,6 +62,12 @@ class RoleWidget(QtWidgets.QWidget):
     def set_timeout(self, timeout: float) -> None:
         self.resource_widget.set_timeout(timeout)
 
+    def baud_rate(self) -> int:
+        return self.resource_widget.baud_rate()
+
+    def set_baud_rate(self, baud_rate: int) -> None:
+        self.resource_widget.set_baud_rate(baud_rate)
+
     def is_reset_instrument(self) -> bool:
         return self.resource_widget.is_reset_instrument()
 
@@ -82,6 +88,7 @@ class RoleWidget(QtWidgets.QWidget):
                 "resource_name": self.resource_name(),
                 "termination": self.termination(),
                 "timeout": self.timeout(),
+                "baud_reate": self.baud_rate(),
             }
             self._resources.setdefault(model, {}).update(resource)
 
@@ -136,6 +143,7 @@ class RoleWidget(QtWidgets.QWidget):
                 self.set_resource_name(resource.get("resource_name", ""))
                 self.set_termination(resource.get("termination", "\r\n"))
                 self.set_timeout(resource.get("timeout", 8.0))
+                self.set_baud_rate(resource.get("baud_rate", 9_600))
                 self.set_reset_instrument(resource.get("reset_instrument", False))
             except Exception as exc:
                 logging.exception(exc)


### PR DESCRIPTION
This PR adds an optional baud rate input for all resources, allowing configuration of the baud rate for serial connections.

It also translates resource names in the format `COM1` into valid VISA resource names such as `ASRL1::INSTR`.