### PR TITLE
Fixing wrong data source for It-plot

### DIFF
--- a/src/diode_measurement/controller.py
+++ b/src/diode_measurement/controller.py
@@ -116,7 +116,7 @@ class Controller(QtCore.QObject):
 
         # Plots
         iv_reading_queue = self.state.create_iv_reading_queue()
-        it_reading_queue = self.state.create_iv_reading_queue()
+        it_reading_queue = self.state.create_it_reading_queue()
         cv_reading_queue = self.state.create_cv_reading_queue()
 
         self.iv_plots_data_windget = IVPlotsDataWidget(iv_reading_queue, it_reading_queue)


### PR DESCRIPTION
This PR fixes a wrong data source for the It plot, currently showing the IV plot data.

This bug was introduced in version 0.26.0