### PR TITLE
Hide baud rate input for non-serial resources

### DIFF
--- a/src/diode_measurement/gui/resource.py
+++ b/src/diode_measurement/gui/resource.py
@@ -233,8 +233,8 @@ class ResourceWidget(QtWidgets.QGroupBox):
             text.startswith("ASRL")
             or text.startswith("COM")
         )
-        self.baud_rate_label.setEnabled(is_serial)
-        self.baud_rate_combo_box.setEnabled(is_serial)
+        self.baud_rate_label.setVisible(is_serial)
+        self.baud_rate_combo_box.setVisible(is_serial)
 
     @QtCore.Slot()
     def on_browse_resources(self) -> None:


### PR DESCRIPTION
This PR hides the resource baud rate input for non-serial resource names to make it more obvious when a baud rate is actually applied.

The baud rate input is only visible if the resource name starts with either `COM` or `ASRL`.