### PR TITLE
Lock browse resources button on measurements

### DIFF
--- a/src/diode_measurement/gui/resource.py
+++ b/src/diode_measurement/gui/resource.py
@@ -158,6 +158,7 @@ class ResourceWidget(QtWidgets.QGroupBox):
     def set_locked(self, state: bool) -> None:
         self.model_combo_box.setEnabled(not state)
         self.resource_line_edit.setEnabled(not state)
+        self.resource_browse_button.setEnabled(not state)
         self.baud_rate_combo_box.setEnabled(not state)
         self.termination_combo_box.setEnabled(not state)
         self.timeout_spin_box.setEnabled(not state)


### PR DESCRIPTION
This PR disables the _Browse Resources_ dialog button while a measurement is running.

Opening the resource browser during an active measurement can create a VISA session race condition, which may cause the measurement to crash.
